### PR TITLE
Install command implementation

### DIFF
--- a/bin/pie
+++ b/bin/pie
@@ -7,6 +7,7 @@ namespace Php\Pie;
 
 use Php\Pie\Command\BuildCommand;
 use Php\Pie\Command\DownloadCommand;
+use Php\Pie\Command\InstallCommand;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\CommandLoader\ContainerCommandLoader;
 use Symfony\Component\Console\Input\InputInterface;
@@ -23,6 +24,7 @@ $application->setCommandLoader(new ContainerCommandLoader(
     [
         'download' => DownloadCommand::class,
         'build' => BuildCommand::class,
+        'install' => InstallCommand::class,
     ]
 ));
 $application->run($container->get(InputInterface::class), $container->get(OutputInterface::class));

--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\Pie\Command;
+
+use Php\Pie\Building\Build;
+use Php\Pie\DependencyResolver\DependencyResolver;
+use Php\Pie\Downloading\DownloadAndExtract;
+use Php\Pie\Installing\Install;
+use Php\Pie\Platform\TargetPlatform;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'install',
+    description: 'Download, build, and install a PIE-compatible PHP extension.',
+)]
+final class InstallCommand extends Command
+{
+    public function __construct(
+        private readonly DependencyResolver $dependencyResolver,
+        private readonly DownloadAndExtract $downloadAndExtract,
+        private readonly Build $build,
+        private readonly Install $install,
+    ) {
+        parent::__construct();
+    }
+
+    public function configure(): void
+    {
+        parent::configure();
+
+        CommandHelper::configureOptions($this);
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if (! TargetPlatform::isRunningAsRoot()) {
+            $output->writeln('This command needs elevated privileges, and may prompt you for your password.');
+        }
+
+        $targetPlatform = CommandHelper::determineTargetPlatformFromInputs($input, $output);
+
+        $requestedNameAndVersionPair = CommandHelper::requestedNameAndVersionPair($input);
+
+        $downloadedPackage = CommandHelper::downloadPackage(
+            $this->dependencyResolver,
+            $targetPlatform,
+            $requestedNameAndVersionPair,
+            $this->downloadAndExtract,
+            $output,
+        );
+
+        CommandHelper::bindConfigureOptionsFromPackage($this, $downloadedPackage->package, $input);
+
+        $configureOptionsValues = CommandHelper::processConfigureOptionsFromInput($downloadedPackage->package, $input);
+
+        ($this->build)($downloadedPackage, $targetPlatform, $configureOptionsValues, $output);
+
+        ($this->install)($downloadedPackage, $targetPlatform, $output);
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Container.php
+++ b/src/Container.php
@@ -33,9 +33,9 @@ use Php\Pie\Downloading\UnixDownloadAndExtract;
 use Php\Pie\Downloading\WindowsDownloadAndExtract;
 use Php\Pie\Installing\Install;
 use Php\Pie\Installing\UnixInstall;
+use Php\Pie\Installing\WindowsInstall;
 use Php\Pie\Platform\TargetPhp\ResolveTargetPhpToPlatformRepository;
 use Psr\Container\ContainerInterface;
-use RuntimeException;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
@@ -135,8 +135,7 @@ final class Container
             Install::class,
             static function (ContainerInterface $container): Install {
                 if (Platform::isWindows()) {
-                    // @todo implement Windows installer
-                    throw new RuntimeException('tbc');
+                    return $container->get(WindowsInstall::class);
                 }
 
                 return $container->get(UnixInstall::class);

--- a/src/Container.php
+++ b/src/Container.php
@@ -135,6 +135,7 @@ final class Container
             Install::class,
             static function (ContainerInterface $container): Install {
                 if (Platform::isWindows()) {
+                    // @todo implement Windows installer
                     throw new RuntimeException('tbc');
                 }
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -21,6 +21,7 @@ use Php\Pie\Building\UnixBuild;
 use Php\Pie\Building\WindowsBuild;
 use Php\Pie\Command\BuildCommand;
 use Php\Pie\Command\DownloadCommand;
+use Php\Pie\Command\InstallCommand;
 use Php\Pie\DependencyResolver\DependencyResolver;
 use Php\Pie\DependencyResolver\ResolveDependencyWithComposer;
 use Php\Pie\Downloading\DownloadAndExtract;
@@ -30,8 +31,11 @@ use Php\Pie\Downloading\GithubPackageReleaseAssets;
 use Php\Pie\Downloading\PackageReleaseAssets;
 use Php\Pie\Downloading\UnixDownloadAndExtract;
 use Php\Pie\Downloading\WindowsDownloadAndExtract;
+use Php\Pie\Installing\Install;
+use Php\Pie\Installing\UnixInstall;
 use Php\Pie\Platform\TargetPhp\ResolveTargetPhpToPlatformRepository;
 use Psr\Container\ContainerInterface;
+use RuntimeException;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
@@ -49,6 +53,7 @@ final class Container
 
         $container->singleton(DownloadCommand::class);
         $container->singleton(BuildCommand::class);
+        $container->singleton(InstallCommand::class);
 
         $container->singleton(IOInterface::class, static function (ContainerInterface $container): IOInterface {
             return new ConsoleIO(
@@ -123,6 +128,17 @@ final class Container
                 }
 
                 return $container->get(UnixBuild::class);
+            },
+        );
+
+        $container->singleton(
+            Install::class,
+            static function (ContainerInterface $container): Install {
+                if (Platform::isWindows()) {
+                    throw new RuntimeException('tbc');
+                }
+
+                return $container->get(UnixInstall::class);
             },
         );
 

--- a/src/DependencyResolver/Package.php
+++ b/src/DependencyResolver/Package.php
@@ -7,6 +7,7 @@ namespace Php\Pie\DependencyResolver;
 use Composer\Package\CompletePackageInterface;
 use Php\Pie\ConfigureOption;
 use Php\Pie\ExtensionName;
+use Php\Pie\ExtensionType;
 
 use function array_key_exists;
 use function array_map;
@@ -23,6 +24,7 @@ final class Package
 
     /** @param list<ConfigureOption> $configureOptions */
     public function __construct(
+        public readonly ExtensionType $extensionType,
         public readonly ExtensionName $extensionName,
         public readonly string $name,
         public readonly string $version,
@@ -43,6 +45,7 @@ final class Package
             : [];
 
         return new self(
+            ExtensionType::tryFrom($completePackage->getType()) ?? ExtensionType::PhpModule,
             ExtensionName::determineFromComposerPackage($completePackage),
             $completePackage->getPrettyName(),
             $completePackage->getPrettyVersion(),

--- a/src/DependencyResolver/ResolveDependencyWithComposer.php
+++ b/src/DependencyResolver/ResolveDependencyWithComposer.php
@@ -7,10 +7,10 @@ namespace Php\Pie\DependencyResolver;
 use Composer\Package\CompletePackageInterface;
 use Composer\Package\Version\VersionSelector;
 use Composer\Repository\RepositorySet;
+use Php\Pie\ExtensionType;
 use Php\Pie\Platform\TargetPhp\ResolveTargetPhpToPlatformRepository;
 use Php\Pie\Platform\TargetPlatform;
 
-use function in_array;
 use function preg_match;
 
 /** @internal This is not public API for PIE, so should not be depended upon unless you accept the risk of BC breaks */
@@ -43,8 +43,7 @@ final class ResolveDependencyWithComposer implements DependencyResolver
             throw UnableToResolveRequirement::fromRequirement($packageName, $requestedVersion);
         }
 
-        $type = $package->getType();
-        if (! in_array($type, [Package::TYPE_PHP_MODULE, Package::TYPE_ZEND_EXTENSION])) {
+        if (! ExtensionType::isValid($package->getType())) {
             throw UnableToResolveRequirement::toPhpOrZendExtension($package, $packageName, $requestedVersion);
         }
 

--- a/src/Downloading/DownloadZip.php
+++ b/src/Downloading/DownloadZip.php
@@ -9,6 +9,8 @@ use Psr\Http\Message\RequestInterface;
 /** @internal This is not public API for PIE, so should not be depended upon unless you accept the risk of BC breaks */
 interface DownloadZip
 {
+    public const DOWNLOADED_ZIP_FILENAME = 'downloaded.zip';
+
     /**
      * @param non-empty-string $localPath
      *

--- a/src/Downloading/DownloadZipWithGuzzle.php
+++ b/src/Downloading/DownloadZipWithGuzzle.php
@@ -12,6 +12,8 @@ use Psr\Http\Message\ResponseInterface;
 use function assert;
 use function file_put_contents;
 
+use const DIRECTORY_SEPARATOR;
+
 /** @internal This is not public API for PIE, so should not be depended upon unless you accept the risk of BC breaks */
 final class DownloadZipWithGuzzle implements DownloadZip
 {
@@ -36,7 +38,7 @@ final class DownloadZipWithGuzzle implements DownloadZip
 
         AssertHttp::responseStatusCode(200, $response);
 
-        $tmpZipFile = $localPath . '/downloaded.zip';
+        $tmpZipFile = $localPath . DIRECTORY_SEPARATOR . DownloadZip::DOWNLOADED_ZIP_FILENAME;
         file_put_contents($tmpZipFile, $response->getBody()->__toString());
 
         return $tmpZipFile;

--- a/src/Downloading/GithubPackageReleaseAssets.php
+++ b/src/Downloading/GithubPackageReleaseAssets.php
@@ -9,16 +9,14 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
 use Php\Pie\DependencyResolver\Package;
-use Php\Pie\Downloading\Exception\CouldNotFindReleaseAsset;
-use Php\Pie\Platform\OperatingSystem;
 use Php\Pie\Platform\TargetPlatform;
+use Php\Pie\Platform\WindowsExtensionAssetName;
 use Psl\Json;
 use Psl\Type;
 use Psr\Http\Message\ResponseInterface;
 
 use function assert;
 use function in_array;
-use function sprintf;
 use function strtolower;
 
 /** @internal This is not public API for PIE, so should not be depended upon unless you accept the risk of BC breaks */
@@ -47,34 +45,7 @@ final class GithubPackageReleaseAssets implements PackageReleaseAssets
     /** @return non-empty-list<non-empty-string> */
     private function expectedWindowsAssetNames(TargetPlatform $targetPlatform, Package $package): array
     {
-        if ($targetPlatform->operatingSystem !== OperatingSystem::Windows || $targetPlatform->windowsCompiler === null) {
-            throw CouldNotFindReleaseAsset::forMissingWindowsCompiler($targetPlatform);
-        }
-
-        /**
-         * During development, we swapped compiler/ts around. It is fairly trivial to support both, so we can check
-         * both formats pretty easily, just to avoid confusion for package maintainers...
-         */
-        return [
-            strtolower(sprintf(
-                'php_%s-%s-%s-%s-%s-%s.zip',
-                $package->extensionName->name(),
-                $package->version,
-                $targetPlatform->phpBinaryPath->majorMinorVersion(),
-                $targetPlatform->threadSafety->asShort(),
-                strtolower($targetPlatform->windowsCompiler->name),
-                $targetPlatform->architecture->name,
-            )),
-            strtolower(sprintf(
-                'php_%s-%s-%s-%s-%s-%s.zip',
-                $package->extensionName->name(),
-                $package->version,
-                $targetPlatform->phpBinaryPath->majorMinorVersion(),
-                strtolower($targetPlatform->windowsCompiler->name),
-                $targetPlatform->threadSafety->asShort(),
-                $targetPlatform->architecture->name,
-            )),
-        ];
+        return WindowsExtensionAssetName::zipNames($targetPlatform, $package);
     }
 
     /** @link https://github.com/squizlabs/PHP_CodeSniffer/issues/3734 */

--- a/src/ExtensionType.php
+++ b/src/ExtensionType.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\Pie;
+
+/** @internal This is not public API for PIE, so should not be depended upon unless you accept the risk of BC breaks */
+enum ExtensionType: string
+{
+    case PhpModule     = 'php-ext';
+    case ZendExtension = 'php-ext-zend';
+
+    public static function isValid(string $toBeChecked): bool
+    {
+        return self::tryFrom($toBeChecked) !== null;
+    }
+}

--- a/src/Installing/Install.php
+++ b/src/Installing/Install.php
@@ -14,6 +14,8 @@ interface Install
     /**
      * Install the extension in the given target platform's PHP, and return the location of the installed shared object
      * or DLL, depending on the platform implementation.
+     *
+     * @return non-empty-string
      */
     public function __invoke(
         DownloadedPackage $downloadedPackage,

--- a/src/Installing/Install.php
+++ b/src/Installing/Install.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\Pie\Installing;
+
+use Php\Pie\Downloading\DownloadedPackage;
+use Php\Pie\Platform\TargetPlatform;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/** @internal This is not public API for PIE, so should not be depended upon unless you accept the risk of BC breaks */
+interface Install
+{
+    public function __invoke(DownloadedPackage $downloadedPackage, TargetPlatform $targetPlatform, OutputInterface $output): void;
+}

--- a/src/Installing/Install.php
+++ b/src/Installing/Install.php
@@ -11,5 +11,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 /** @internal This is not public API for PIE, so should not be depended upon unless you accept the risk of BC breaks */
 interface Install
 {
-    public function __invoke(DownloadedPackage $downloadedPackage, TargetPlatform $targetPlatform, OutputInterface $output): void;
+    /**
+     * Install the extension in the given target platform's PHP, and return the location of the installed shared object
+     * or DLL, depending on the platform implementation.
+     */
+    public function __invoke(
+        DownloadedPackage $downloadedPackage,
+        TargetPlatform $targetPlatform,
+        OutputInterface $output,
+    ): string;
 }

--- a/src/Installing/UnixInstall.php
+++ b/src/Installing/UnixInstall.php
@@ -7,21 +7,34 @@ namespace Php\Pie\Installing;
 use Php\Pie\Downloading\DownloadedPackage;
 use Php\Pie\ExtensionType;
 use Php\Pie\Platform\TargetPlatform;
+use RuntimeException;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 
+use function file_exists;
 use function sprintf;
 
 /** @internal This is not public API for PIE, so should not be depended upon unless you accept the risk of BC breaks */
 final class UnixInstall implements Install
 {
-    public function __invoke(DownloadedPackage $downloadedPackage, TargetPlatform $targetPlatform, OutputInterface $output): void
+    public function __invoke(DownloadedPackage $downloadedPackage, TargetPlatform $targetPlatform, OutputInterface $output): string
     {
         (new Process(['sudo', 'make', 'install'], $downloadedPackage->extractedSourcePath))
             ->mustRun()
             ->getOutput();
 
-        $output->writeln('<info>Install complete.</info>');
+        $sharedObjectName             = $downloadedPackage->package->extensionName->name() . '.so';
+        $expectedSharedObjectLocation = sprintf(
+            '%s/%s',
+            $targetPlatform->phpBinaryPath->extensionPath(),
+            $sharedObjectName,
+        );
+
+        if (! file_exists($expectedSharedObjectLocation)) {
+            throw new RuntimeException('Install failed, ' . $expectedSharedObjectLocation . ' was not installed.');
+        }
+
+        $output->writeln('<info>Install complete:</info> ' . $expectedSharedObjectLocation);
 
         /**
          * @link https://github.com/php/pie/issues/20
@@ -29,9 +42,11 @@ final class UnixInstall implements Install
          * @todo this should be improved in future to try to automatically set up the ext
          */
         $output->writeln(sprintf(
-            '<comment>You must now add "%s=%s.so" to your php.ini</comment>',
+            '<comment>You must now add "%s=%s" to your php.ini</comment>',
             $downloadedPackage->package->extensionType === ExtensionType::PhpModule ? 'extension' : 'zend_extension',
-            $downloadedPackage->package->extensionName->name(),
+            $sharedObjectName,
         ));
+
+        return $expectedSharedObjectLocation;
     }
 }

--- a/src/Installing/UnixInstall.php
+++ b/src/Installing/UnixInstall.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\Pie\Installing;
+
+use Php\Pie\Downloading\DownloadedPackage;
+use Php\Pie\Platform\TargetPlatform;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Process;
+
+/** @internal This is not public API for PIE, so should not be depended upon unless you accept the risk of BC breaks */
+final class UnixInstall implements Install
+{
+    public function __invoke(DownloadedPackage $downloadedPackage, TargetPlatform $targetPlatform, OutputInterface $output): void
+    {
+        (new Process(['sudo', 'make', 'install'], $downloadedPackage->extractedSourcePath))
+            ->mustRun()
+            ->getOutput();
+
+        $output->writeln('<info>Install complete.</info>');
+
+        // @todo write info on php.ini change to make
+    }
+}

--- a/src/Installing/UnixInstall.php
+++ b/src/Installing/UnixInstall.php
@@ -44,7 +44,7 @@ final class UnixInstall implements Install
         $output->writeln(sprintf(
             '<comment>You must now add "%s=%s" to your php.ini</comment>',
             $downloadedPackage->package->extensionType === ExtensionType::PhpModule ? 'extension' : 'zend_extension',
-            $sharedObjectName,
+            $downloadedPackage->package->extensionName->name(),
         ));
 
         return $expectedSharedObjectLocation;

--- a/src/Installing/UnixInstall.php
+++ b/src/Installing/UnixInstall.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace Php\Pie\Installing;
 
 use Php\Pie\Downloading\DownloadedPackage;
+use Php\Pie\ExtensionType;
 use Php\Pie\Platform\TargetPlatform;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
+
+use function sprintf;
 
 /** @internal This is not public API for PIE, so should not be depended upon unless you accept the risk of BC breaks */
 final class UnixInstall implements Install
@@ -20,6 +23,15 @@ final class UnixInstall implements Install
 
         $output->writeln('<info>Install complete.</info>');
 
-        // @todo write info on php.ini change to make
+        /**
+         * @link https://github.com/php/pie/issues/20
+         *
+         * @todo this should be improved in future to try to automatically set up the ext
+         */
+        $output->writeln(sprintf(
+            '<comment>You must now add "%s=%s.so" to your php.ini</comment>',
+            $downloadedPackage->package->extensionType === ExtensionType::PhpModule ? 'extension' : 'zend_extension',
+            $downloadedPackage->package->extensionName->name(),
+        ));
     }
 }

--- a/src/Installing/WindowsInstall.php
+++ b/src/Installing/WindowsInstall.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Php\Pie\Installing;
 
 use Php\Pie\Downloading\DownloadedPackage;
+use Php\Pie\ExtensionType;
 use Php\Pie\Platform\TargetPlatform;
 use Php\Pie\Platform\WindowsExtensionAssetName;
 use RuntimeException;
@@ -14,6 +15,7 @@ use function copy;
 use function file_exists;
 use function implode;
 use function is_file;
+use function sprintf;
 use function str_replace;
 
 use const DIRECTORY_SEPARATOR;
@@ -46,6 +48,17 @@ final class WindowsInstall implements Install
 
         // @todo copy any OTHER .dll file next to `C:\path\to\php\php.exe`
         // @todo copy any other file (excluding those above, and `downloaded.zip`) to `C:\path\to\php\extras\{extension-name}\.`
+
+        /**
+         * @link https://github.com/php/pie/issues/20
+         *
+         * @todo this should be improved in future to try to automatically set up the ext
+         */
+        $output->writeln(sprintf(
+            '<comment>You must now add "%s=%s" to your php.ini</comment>',
+            $downloadedPackage->package->extensionType === ExtensionType::PhpModule ? 'extension' : 'zend_extension',
+            $downloadedPackage->package->extensionName->name(),
+        ));
 
         return $destinationDllName;
     }

--- a/src/Installing/WindowsInstall.php
+++ b/src/Installing/WindowsInstall.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\Pie\Installing;
+
+use Php\Pie\Downloading\DownloadedPackage;
+use Php\Pie\Platform\TargetPlatform;
+use Php\Pie\Platform\WindowsExtensionAssetName;
+use RuntimeException;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function copy;
+use function file_exists;
+use function implode;
+use function is_file;
+use function str_replace;
+
+use const DIRECTORY_SEPARATOR;
+
+/** @internal This is not public API for PIE, so should not be depended upon unless you accept the risk of BC breaks */
+final class WindowsInstall implements Install
+{
+    public function __invoke(DownloadedPackage $downloadedPackage, TargetPlatform $targetPlatform, OutputInterface $output): string
+    {
+        $sourceDllName      = $this->determineDllName($targetPlatform, $downloadedPackage);
+        $extensionPath      = $targetPlatform->phpBinaryPath->extensionPath();
+        $destinationDllName = $extensionPath . DIRECTORY_SEPARATOR . 'php_' . $downloadedPackage->package->extensionName->name() . '.dll';
+
+        if (! copy($sourceDllName, $destinationDllName) || ! file_exists($destinationDllName) && ! is_file($destinationDllName)) {
+            throw new RuntimeException('Failed to install DLL to ' . $destinationDllName);
+        }
+
+        $output->writeln('<info>Copied DLL to:</info> ' . $destinationDllName);
+
+        $sourcePdbName = str_replace('.dll', '.pdb', $sourceDllName);
+        if (file_exists($sourcePdbName)) {
+            $destinationPdbName = str_replace('.dll', '.pdb', $destinationDllName);
+
+            if (! copy($sourcePdbName, $destinationPdbName) || ! file_exists($destinationPdbName) && ! is_file($destinationPdbName)) {
+                throw new RuntimeException('Failed to install PDB to ' . $destinationPdbName);
+            }
+
+            $output->writeln('<info>Copied PDB to:</info> ' . $destinationPdbName);
+        }
+
+        // @todo copy any OTHER .dll file next to `C:\path\to\php\php.exe`
+        // @todo copy any other file (excluding those above, and `downloaded.zip`) to `C:\path\to\php\extras\{extension-name}\.`
+
+        return $destinationDllName;
+    }
+
+    /** @return non-empty-string */
+    private function determineDllName(TargetPlatform $targetPlatform, DownloadedPackage $package): string
+    {
+        $possibleDllNames = WindowsExtensionAssetName::dllNames($targetPlatform, $package->package);
+        foreach ($possibleDllNames as $dllName) {
+            $fullDllName = $package->extractedSourcePath . '/' . $dllName;
+            if (file_exists($fullDllName)) {
+                return $fullDllName;
+            }
+        }
+
+        throw new RuntimeException('Unable to find DLL for package, checked: ' . implode(', ', $possibleDllNames));
+    }
+}

--- a/src/Installing/WindowsInstall.php
+++ b/src/Installing/WindowsInstall.php
@@ -36,70 +36,40 @@ final class WindowsInstall implements Install
     {
         $extractedSourcePath = $downloadedPackage->extractedSourcePath;
         $sourceDllName       = $this->determineDllName($targetPlatform, $downloadedPackage);
-        $extensionPath       = $targetPlatform->phpBinaryPath->extensionPath();
-        $destinationDllName  = $extensionPath . DIRECTORY_SEPARATOR . 'php_' . $downloadedPackage->package->extensionName->name() . '.dll';
+        $sourcePdbName       = str_replace('.dll', '.pdb', $sourceDllName);
+        assert($sourcePdbName !== '');
 
-        if (! copy($sourceDllName, $destinationDllName) || ! file_exists($destinationDllName) && ! is_file($destinationDllName)) {
-            throw new RuntimeException('Failed to install DLL to ' . $destinationDllName);
-        }
-
+        $destinationDllName = $this->copyExtensionDll($targetPlatform, $downloadedPackage, $sourceDllName);
         $output->writeln('<info>Copied DLL to:</info> ' . $destinationDllName);
 
-        $sourcePdbName = str_replace('.dll', '.pdb', $sourceDllName);
-        if (file_exists($sourcePdbName)) {
-            $destinationPdbName = str_replace('.dll', '.pdb', $destinationDllName);
-
-            if (! copy($sourcePdbName, $destinationPdbName) || ! file_exists($destinationPdbName) && ! is_file($destinationPdbName)) {
-                throw new RuntimeException('Failed to install PDB to ' . $destinationPdbName);
-            }
-
+        $destinationPdbName = $this->copyExtensionPdb($targetPlatform, $downloadedPackage, $sourcePdbName, $destinationDllName);
+        if ($destinationPdbName !== null) {
             $output->writeln('<info>Copied PDB to:</info> ' . $destinationPdbName);
         }
 
-        $phpPath    = dirname($targetPlatform->phpBinaryPath->phpBinaryPath);
-        $extrasPath = $phpPath
-            . DIRECTORY_SEPARATOR . 'extras'
-            . DIRECTORY_SEPARATOR . $downloadedPackage->package->extensionName->name();
-
         foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($extractedSourcePath)) as $file) {
             assert($file instanceof SplFileInfo);
+
             /**
              * Skip directories, the main DLL, PDB, and the downloaded.zip
              */
             if (
                 $file->isDir()
-                || str_replace('\\', '/', $file->getPathname()) === str_replace('\\', '/', $sourceDllName)
-                || str_replace('\\', '/', $file->getPathname()) === str_replace('\\', '/', $sourcePdbName)
+                || $this->normalisedPathsMatch($file->getPathname(), $sourceDllName)
+                || $this->normalisedPathsMatch($file->getPathname(), $sourcePdbName)
                 || $file->getFilename() === DownloadZip::DOWNLOADED_ZIP_FILENAME
             ) {
                 continue;
             }
 
-            /**
-             * Any other DLL file should be copied into the same path where `php.exe` is
-             */
-            if ($file->getExtension() === 'dll') {
-                $destinationExtraDll = $phpPath . DIRECTORY_SEPARATOR . $file->getFilename();
-                if (! copy($file->getPathname(), $destinationExtraDll) || ! file_exists($destinationExtraDll) && ! is_file($destinationExtraDll)) {
-                    throw new RuntimeException('Failed to copy to ' . $destinationExtraDll);
-                }
-
+            $destinationExtraDll = $this->copyDependencyDll($targetPlatform, $file);
+            if ($destinationExtraDll !== null) {
                 $output->writeln('<info>Copied extra DLL:</info> ' . $destinationExtraDll);
 
                 continue;
             }
 
-            /**
-             * Any other remaining file should be copied into the extras path, e.g. `C:\php\extras\my-php-ext\.`
-             */
-            $destinationPathname = $extrasPath . DIRECTORY_SEPARATOR . substr($file->getPathname(), strlen($extractedSourcePath) + 1);
-
-            mkdir(dirname($destinationPathname), 0777, true);
-
-            if (! copy($file->getPathname(), $destinationPathname) || ! file_exists($destinationPathname) && ! is_file($destinationPathname)) {
-                throw new RuntimeException('Failed to copy to ' . $destinationPathname);
-            }
-
+            $destinationPathname = $this->copyExtraFile($targetPlatform, $downloadedPackage, $file);
             $output->writeln('<info>Copied extras:</info> ' . $destinationPathname);
         }
 
@@ -129,5 +99,108 @@ final class WindowsInstall implements Install
         }
 
         throw new RuntimeException('Unable to find DLL for package, checked: ' . implode(', ', $possibleDllNames));
+    }
+
+    /**
+     * Normalise both path parameters (i.e. replace `\` with `/`) and compare them. Useful if the two paths are built
+     * differently with different/incorrect directory separators, e.g. "C:\path\to/thing" vs "C:\path\to\thing"
+     */
+    private function normalisedPathsMatch(string $first, string $second): bool
+    {
+        return str_replace('\\', '/', $first) === str_replace('\\', '/', $second);
+    }
+
+    /**
+     * Copy the main PHP extension DLL into the extension path.
+     *
+     * @param non-empty-string $sourceDllName
+     *
+     * @return non-empty-string
+     */
+    private function copyExtensionDll(TargetPlatform $targetPlatform, DownloadedPackage $downloadedPackage, string $sourceDllName): string
+    {
+        $destinationDllName = $targetPlatform->phpBinaryPath->extensionPath() . DIRECTORY_SEPARATOR
+            . 'php_' . $downloadedPackage->package->extensionName->name() . '.dll';
+
+        if (! copy($sourceDllName, $destinationDllName) || ! file_exists($destinationDllName) && ! is_file($destinationDllName)) {
+            throw new RuntimeException('Failed to install DLL to ' . $destinationDllName);
+        }
+
+        return $destinationDllName;
+    }
+
+    /**
+     * Copy the PDB (Program Database, which is debugging information basically), into the same directory as the DLL,
+     * if it exists.
+     *
+     * Returns `null` if the source PDB does not exist (and thus, does not need to be copied).
+     *
+     * @param non-empty-string $sourcePdbName
+     * @param non-empty-string $destinationDllName
+     *
+     * @return non-empty-string|null
+     */
+    private function copyExtensionPdb(TargetPlatform $targetPlatform, DownloadedPackage $downloadedPackage, string $sourcePdbName, string $destinationDllName): string|null
+    {
+        if (! file_exists($sourcePdbName)) {
+            return null;
+        }
+
+        $destinationPdbName = str_replace('.dll', '.pdb', $destinationDllName);
+        assert($destinationPdbName !== '');
+
+        if (! copy($sourcePdbName, $destinationPdbName) || ! file_exists($destinationPdbName) && ! is_file($destinationPdbName)) {
+            throw new RuntimeException('Failed to install PDB to ' . $destinationPdbName);
+        }
+
+        return $destinationPdbName;
+    }
+
+    /**
+     * Any other DLL file included in the source package should be copied into the same path where `php.exe` is - these
+     * would commonly be dependencies/libraries that the extension depends on, and is bundled with.
+     *
+     * If the file is NOT a DLL, this method will return `null`
+     *
+     * @return non-empty-string|null
+     */
+    private function copyDependencyDll(TargetPlatform $targetPlatform, SplFileInfo $file): string|null
+    {
+        if ($file->getExtension() !== 'dll') {
+            return null;
+        }
+
+        $destinationExtraDll = dirname($targetPlatform->phpBinaryPath->phpBinaryPath) . DIRECTORY_SEPARATOR . $file->getFilename();
+
+        if (! copy($file->getPathname(), $destinationExtraDll) || ! file_exists($destinationExtraDll) && ! is_file($destinationExtraDll)) {
+            throw new RuntimeException('Failed to copy to ' . $destinationExtraDll);
+        }
+
+        return $destinationExtraDll;
+    }
+
+    /**
+     * Any other remaining file should be copied into the "extras" path, e.g. `C:\php\extras\my-php-ext\.`
+     *
+     * @return non-empty-string
+     */
+    private function copyExtraFile(TargetPlatform $targetPlatform, DownloadedPackage $downloadedPackage, SplFileInfo $file): string
+    {
+        $destinationFullFilename = dirname($targetPlatform->phpBinaryPath->phpBinaryPath) . DIRECTORY_SEPARATOR
+            . 'extras' . DIRECTORY_SEPARATOR
+            . $downloadedPackage->package->extensionName->name() . DIRECTORY_SEPARATOR
+            . substr($file->getPathname(), strlen($downloadedPackage->extractedSourcePath) + 1);
+
+        $destinationPath = dirname($destinationFullFilename);
+
+        if (! file_exists($destinationPath)) {
+            mkdir($destinationPath, 0777, true);
+        }
+
+        if (! copy($file->getPathname(), $destinationFullFilename) || ! file_exists($destinationFullFilename) && ! is_file($destinationFullFilename)) {
+            throw new RuntimeException('Failed to copy to ' . $destinationFullFilename);
+        }
+
+        return $destinationFullFilename;
     }
 }

--- a/src/Platform/TargetPlatform.php
+++ b/src/Platform/TargetPlatform.php
@@ -8,6 +8,8 @@ use Php\Pie\Platform\TargetPhp\PhpBinaryPath;
 
 use function array_key_exists;
 use function explode;
+use function function_exists;
+use function posix_getuid;
 use function preg_match;
 use function trim;
 
@@ -25,6 +27,11 @@ class TargetPlatform
         public readonly ThreadSafetyMode $threadSafety,
         public readonly WindowsCompiler|null $windowsCompiler,
     ) {
+    }
+
+    public static function isRunningAsRoot(): bool
+    {
+        return function_exists('posix_getuid') && posix_getuid() === 0;
     }
 
     public static function fromPhpBinaryPath(PhpBinaryPath $phpBinaryPath): self

--- a/src/Platform/WindowsExtensionAssetName.php
+++ b/src/Platform/WindowsExtensionAssetName.php
@@ -58,4 +58,10 @@ final class WindowsExtensionAssetName
     {
         return self::assetNames($targetPlatform, $package, 'zip');
     }
+
+    /** @return non-empty-list<non-empty-string> */
+    public static function dllNames(TargetPlatform $targetPlatform, Package $package): array
+    {
+        return self::assetNames($targetPlatform, $package, 'dll');
+    }
 }

--- a/src/Platform/WindowsExtensionAssetName.php
+++ b/src/Platform/WindowsExtensionAssetName.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\Pie\Platform;
+
+use Php\Pie\DependencyResolver\Package;
+use Php\Pie\Downloading\Exception\CouldNotFindReleaseAsset;
+
+use function sprintf;
+use function strtolower;
+
+/** @internal This is not public API for PIE, so should not be depended upon unless you accept the risk of BC breaks */
+final class WindowsExtensionAssetName
+{
+    /** @psalm-suppress UnusedConstructor */
+    private function __construct()
+    {
+    }
+
+    /** @return non-empty-list<non-empty-string> */
+    private static function assetNames(TargetPlatform $targetPlatform, Package $package, string $fileExtension): array
+    {
+        if ($targetPlatform->operatingSystem !== OperatingSystem::Windows || $targetPlatform->windowsCompiler === null) {
+            throw CouldNotFindReleaseAsset::forMissingWindowsCompiler($targetPlatform);
+        }
+
+        /**
+         * During development, we swapped compiler/ts around. It is fairly trivial to support both, so we can check
+         * both formats pretty easily, just to avoid confusion for package maintainers...
+         */
+        return [
+            strtolower(sprintf(
+                'php_%s-%s-%s-%s-%s-%s.%s',
+                $package->extensionName->name(),
+                $package->version,
+                $targetPlatform->phpBinaryPath->majorMinorVersion(),
+                $targetPlatform->threadSafety->asShort(),
+                strtolower($targetPlatform->windowsCompiler->name),
+                $targetPlatform->architecture->name,
+                $fileExtension,
+            )),
+            strtolower(sprintf(
+                'php_%s-%s-%s-%s-%s-%s.%s',
+                $package->extensionName->name(),
+                $package->version,
+                $targetPlatform->phpBinaryPath->majorMinorVersion(),
+                strtolower($targetPlatform->windowsCompiler->name),
+                $targetPlatform->threadSafety->asShort(),
+                $targetPlatform->architecture->name,
+                $fileExtension,
+            )),
+        ];
+    }
+
+    /** @return non-empty-list<non-empty-string> */
+    public static function zipNames(TargetPlatform $targetPlatform, Package $package): array
+    {
+        return self::assetNames($targetPlatform, $package, 'zip');
+    }
+}

--- a/test/assets/pie_test_ext_win/README.md
+++ b/test/assets/pie_test_ext_win/README.md
@@ -1,0 +1,10 @@
+This is just an example file structure for a Windows PHP module.
+
+Note that NONE of the .dll and .pdb files here are actually binaries!
+
+Given the PHP path of `C:\php\php.exe`:
+
+ - `php_pie_test_ext-1.2.3-8.3-ts-vs16-x86_64.dll` should be installed to `C:\php\ext\php_pie_test_ext.dll`
+ - `php_pie_test_ext-1.2.3-8.3-ts-vs16-x86_64.pdb` should be installed to `C:\php\ext\php_pie_test_ext.pdb`
+ - `supporting-library.dll` should be installed to `C:\php\supporting-library.dll`
+ - `README.md` should be installed to `C:\php\extras\pie_test_ext\README.md`

--- a/test/assets/pie_test_ext_win/more/more-information.txt
+++ b/test/assets/pie_test_ext_win/more/more-information.txt
@@ -1,0 +1,1 @@
+only a test file

--- a/test/assets/pie_test_ext_win/php_pie_test_ext-1.2.3-8.1-ts-vs16-x86_64.dll
+++ b/test/assets/pie_test_ext_win/php_pie_test_ext-1.2.3-8.1-ts-vs16-x86_64.dll
@@ -1,0 +1,1 @@
+only a test file

--- a/test/assets/pie_test_ext_win/php_pie_test_ext-1.2.3-8.1-ts-vs16-x86_64.pdb
+++ b/test/assets/pie_test_ext_win/php_pie_test_ext-1.2.3-8.1-ts-vs16-x86_64.pdb
@@ -1,0 +1,1 @@
+only a test file

--- a/test/assets/pie_test_ext_win/php_pie_test_ext-1.2.3-8.2-ts-vs16-x86_64.dll
+++ b/test/assets/pie_test_ext_win/php_pie_test_ext-1.2.3-8.2-ts-vs16-x86_64.dll
@@ -1,0 +1,1 @@
+only a test file

--- a/test/assets/pie_test_ext_win/php_pie_test_ext-1.2.3-8.2-ts-vs16-x86_64.pdb
+++ b/test/assets/pie_test_ext_win/php_pie_test_ext-1.2.3-8.2-ts-vs16-x86_64.pdb
@@ -1,0 +1,1 @@
+only a test file

--- a/test/assets/pie_test_ext_win/php_pie_test_ext-1.2.3-8.3-ts-vs16-x86_64.dll
+++ b/test/assets/pie_test_ext_win/php_pie_test_ext-1.2.3-8.3-ts-vs16-x86_64.dll
@@ -1,0 +1,1 @@
+only a test file

--- a/test/assets/pie_test_ext_win/php_pie_test_ext-1.2.3-8.3-ts-vs16-x86_64.pdb
+++ b/test/assets/pie_test_ext_win/php_pie_test_ext-1.2.3-8.3-ts-vs16-x86_64.pdb
@@ -1,0 +1,1 @@
+only a test file

--- a/test/assets/pie_test_ext_win/supporting-library.dll
+++ b/test/assets/pie_test_ext_win/supporting-library.dll
@@ -1,0 +1,1 @@
+only a test file

--- a/test/integration/Building/UnixBuildTest.php
+++ b/test/integration/Building/UnixBuildTest.php
@@ -10,6 +10,7 @@ use Php\Pie\ConfigureOption;
 use Php\Pie\DependencyResolver\Package;
 use Php\Pie\Downloading\DownloadedPackage;
 use Php\Pie\ExtensionName;
+use Php\Pie\ExtensionType;
 use Php\Pie\Platform\TargetPhp\PhpBinaryPath;
 use Php\Pie\Platform\TargetPlatform;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -32,6 +33,7 @@ final class UnixBuildTest extends TestCase
 
         $downloadedPackage = DownloadedPackage::fromPackageAndExtractedPath(
             new Package(
+                ExtensionType::PhpModule,
                 ExtensionName::normaliseFromString('pie_test_ext'),
                 'pie_test_ext',
                 '0.1.0',

--- a/test/integration/Command/BuildCommandTest.php
+++ b/test/integration/Command/BuildCommandTest.php
@@ -38,8 +38,6 @@ class BuildCommandTest extends TestCase
 
         $outputString = $this->commandTester->getDisplay();
 
-        self::assertStringContainsString('Found package: asgrim/example-pie-extension:1.0.1 which provides ext-example_pie_extension', $outputString);
-
         if (Platform::isWindows()) {
             self::assertStringContainsString('Nothing to do on Windows.', $outputString);
 

--- a/test/integration/Command/InstallCommandTest.php
+++ b/test/integration/Command/InstallCommandTest.php
@@ -32,109 +32,18 @@ class InstallCommandTest extends TestCase
         $this->commandTester = new CommandTester(Container::factory()->get(InstallCommand::class));
     }
 
-    /**
-     * @return array<non-empty-string, array{0: non-empty-string, 1: non-empty-string}>
-     *
-     * @psalm-suppress PossiblyUnusedMethod https://github.com/psalm/psalm-plugin-phpunit/issues/131
-     */
-    public static function validVersionsList(): array
-    {
-        $versionsAndExpected = [
-            [self::TEST_PACKAGE, self::TEST_PACKAGE . ':1.0.1'],
-            [self::TEST_PACKAGE . ':^1.0', self::TEST_PACKAGE . ':1.0.1'],
-            [self::TEST_PACKAGE . ':1.0.1-alpha.3@alpha', self::TEST_PACKAGE . ':1.0.1-alpha.3'],
-            [self::TEST_PACKAGE . ':*', self::TEST_PACKAGE . ':1.0.1'],
-            [self::TEST_PACKAGE . ':~1.0.0@alpha', self::TEST_PACKAGE . ':1.0.1'],
-            [self::TEST_PACKAGE . ':^1.1.0@alpha', self::TEST_PACKAGE . ':1.1.0-alpha.4'],
-            [self::TEST_PACKAGE . ':~1.0.0', self::TEST_PACKAGE . ':1.0.1'],
-            // @todo https://github.com/php/pie/issues/13 - in theory, these could work, on NonWindows at least
-            // [self::TEST_PACKAGE . ':dev-main', self::TEST_PACKAGE . ':???'],
-            // [self::TEST_PACKAGE . ':dev-main#769f906413d6d1e12152f6d34134cbcd347ca253', self::TEST_PACKAGE . ':???'],
-        ];
-
-        return array_combine(
-            array_map(static fn ($item) => $item[0], $versionsAndExpected),
-            $versionsAndExpected,
-        );
-    }
-
-    #[DataProvider('validVersionsList')]
-    public function testInstallCommandWillInstallCompatibleExtension(string $requestedVersion, string $expectedVersion): void
+    public function testInstallCommandWillInstallCompatibleExtension(): void
     {
         if (PHP_VERSION_ID < 80300 || PHP_VERSION_ID >= 80400) {
             self::markTestSkipped('This test can only run on PHP 8.3 - you are running ' . PHP_VERSION);
         }
 
-        $this->commandTester->execute(['requested-package-and-version' => $requestedVersion]);
+        $this->commandTester->execute(['requested-package-and-version' => self::TEST_PACKAGE]);
 
         $this->commandTester->assertCommandIsSuccessful();
 
         $outputString = $this->commandTester->getDisplay();
-        self::assertStringContainsString('Found package: ' . $expectedVersion . ' which provides', $outputString);
-        self::assertStringContainsString('phpize complete.', $outputString);
-        self::assertStringContainsString('Configure complete.', $outputString);
-        self::assertStringContainsString('Build complete:', $outputString);
         self::assertStringContainsString('Install complete.', $outputString);
         self::assertStringContainsString('You must now add "extension=example_pie_extension.so" to your php.ini', $outputString);
-    }
-
-    #[DataProvider('validVersionsList')]
-    public function testInstallingWithPhpConfig(string $requestedVersion, string $expectedVersion): void
-    {
-        // @todo This test makes an assumption you're using `ppa:ondrej/php` to have multiple PHP versions. This allows
-        //       us to test scenarios where you run with PHP 8.1 but want to install to a PHP 8.3 instance, for example.
-        //       However, this test isn't very portable, and won't run in CI, so we could do with improving this later.
-        $phpConfigPath = '/usr/bin/php-config8.3';
-
-        if (! file_exists($phpConfigPath) || ! is_executable($phpConfigPath)) {
-            self::markTestSkipped('This test can only run where "' . $phpConfigPath . '" exists and is executable, to target PHP 8.3');
-        }
-
-        $this->commandTester->execute([
-            '--with-php-config' => $phpConfigPath,
-            'requested-package-and-version' => $requestedVersion,
-        ]);
-
-        $this->commandTester->assertCommandIsSuccessful();
-
-        $outputString = $this->commandTester->getDisplay();
-        self::assertStringContainsString('Found package: ' . $expectedVersion . ' which provides', $outputString);
-        self::assertStringContainsString('Configure complete with options: --with-php-config=', $outputString);
-        self::assertStringContainsString('Install complete.', $outputString);
-    }
-
-    #[DataProvider('validVersionsList')]
-    public function testInstallingWithPhpPath(string $requestedVersion, string $expectedVersion): void
-    {
-        // @todo This test makes an assumption you're using `ppa:ondrej/php` to have multiple PHP versions. This allows
-        //       us to test scenarios where you run with PHP 8.1 but want to install to a PHP 8.3 instance, for example.
-        //       However, this test isn't very portable, and won't run in CI, so we could do with improving this later.
-        $phpBinaryPath = '/usr/bin/php8.3';
-
-        if (! file_exists($phpBinaryPath) || ! is_executable($phpBinaryPath)) {
-            self::markTestSkipped('This test can only run where "' . $phpBinaryPath . '" exists and is executable, to target PHP 8.3');
-        }
-
-        $this->commandTester->execute([
-            '--with-php-path' => $phpBinaryPath,
-            'requested-package-and-version' => $requestedVersion,
-        ]);
-
-        $this->commandTester->assertCommandIsSuccessful();
-
-        $outputString = $this->commandTester->getDisplay();
-        self::assertStringContainsString('Found package: ' . $expectedVersion . ' which provides', $outputString);
-        self::assertStringContainsString('Install complete.', $outputString);
-    }
-
-    public function testInstallCommandFailsWhenUsingIncompatiblePhpVersion(): void
-    {
-        if (PHP_VERSION_ID >= 80200) {
-            self::markTestSkipped('This test can only run on older than PHP 8.2 - you are running ' . PHP_VERSION);
-        }
-
-        $this->expectException(UnableToResolveRequirement::class);
-        // 1.0.0 is only compatible with PHP 8.3.0
-        $this->commandTester->execute(['requested-package-and-version' => self::TEST_PACKAGE . ':1.0.0']);
     }
 }

--- a/test/integration/Command/InstallCommandTest.php
+++ b/test/integration/Command/InstallCommandTest.php
@@ -50,7 +50,7 @@ class InstallCommandTest extends TestCase
 
         $outputString = $this->commandTester->getDisplay();
         self::assertStringContainsString('Install complete: ', $outputString);
-        self::assertStringContainsString('You must now add "extension=example_pie_extension.so" to your php.ini', $outputString);
+        self::assertStringContainsString('You must now add "extension=example_pie_extension" to your php.ini', $outputString);
 
         if (
             ! preg_match('#^Install complete: (.*)$#m', $outputString, $matches)

--- a/test/integration/Command/InstallCommandTest.php
+++ b/test/integration/Command/InstallCommandTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\PieIntegrationTest\Command;
+
+use Php\Pie\Command\InstallCommand;
+use Php\Pie\Container;
+use Php\Pie\DependencyResolver\UnableToResolveRequirement;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+use function array_combine;
+use function array_map;
+use function file_exists;
+use function is_executable;
+
+use const PHP_VERSION;
+use const PHP_VERSION_ID;
+
+#[CoversClass(InstallCommand::class)]
+class InstallCommandTest extends TestCase
+{
+    private const TEST_PACKAGE = 'asgrim/example-pie-extension';
+
+    private CommandTester $commandTester;
+
+    public function setUp(): void
+    {
+        $this->commandTester = new CommandTester(Container::factory()->get(InstallCommand::class));
+    }
+
+    /**
+     * @return array<non-empty-string, array{0: non-empty-string, 1: non-empty-string}>
+     *
+     * @psalm-suppress PossiblyUnusedMethod https://github.com/psalm/psalm-plugin-phpunit/issues/131
+     */
+    public static function validVersionsList(): array
+    {
+        $versionsAndExpected = [
+            [self::TEST_PACKAGE, self::TEST_PACKAGE . ':1.0.1'],
+            [self::TEST_PACKAGE . ':^1.0', self::TEST_PACKAGE . ':1.0.1'],
+            [self::TEST_PACKAGE . ':1.0.1-alpha.3@alpha', self::TEST_PACKAGE . ':1.0.1-alpha.3'],
+            [self::TEST_PACKAGE . ':*', self::TEST_PACKAGE . ':1.0.1'],
+            [self::TEST_PACKAGE . ':~1.0.0@alpha', self::TEST_PACKAGE . ':1.0.1'],
+            [self::TEST_PACKAGE . ':^1.1.0@alpha', self::TEST_PACKAGE . ':1.1.0-alpha.4'],
+            [self::TEST_PACKAGE . ':~1.0.0', self::TEST_PACKAGE . ':1.0.1'],
+            // @todo https://github.com/php/pie/issues/13 - in theory, these could work, on NonWindows at least
+            // [self::TEST_PACKAGE . ':dev-main', self::TEST_PACKAGE . ':???'],
+            // [self::TEST_PACKAGE . ':dev-main#769f906413d6d1e12152f6d34134cbcd347ca253', self::TEST_PACKAGE . ':???'],
+        ];
+
+        return array_combine(
+            array_map(static fn ($item) => $item[0], $versionsAndExpected),
+            $versionsAndExpected,
+        );
+    }
+
+    #[DataProvider('validVersionsList')]
+    public function testInstallCommandWillInstallCompatibleExtension(string $requestedVersion, string $expectedVersion): void
+    {
+        if (PHP_VERSION_ID < 80300 || PHP_VERSION_ID >= 80400) {
+            self::markTestSkipped('This test can only run on PHP 8.3 - you are running ' . PHP_VERSION);
+        }
+
+        $this->commandTester->execute(['requested-package-and-version' => $requestedVersion]);
+
+        $this->commandTester->assertCommandIsSuccessful();
+
+        $outputString = $this->commandTester->getDisplay();
+        self::assertStringContainsString('Found package: ' . $expectedVersion . ' which provides', $outputString);
+        self::assertStringContainsString('phpize complete.', $outputString);
+        self::assertStringContainsString('Configure complete.', $outputString);
+        self::assertStringContainsString('Build complete:', $outputString);
+        self::assertStringContainsString('Install complete.', $outputString);
+        self::assertStringContainsString('You must now add "extension=example_pie_extension.so" to your php.ini', $outputString);
+    }
+
+    #[DataProvider('validVersionsList')]
+    public function testInstallingWithPhpConfig(string $requestedVersion, string $expectedVersion): void
+    {
+        // @todo This test makes an assumption you're using `ppa:ondrej/php` to have multiple PHP versions. This allows
+        //       us to test scenarios where you run with PHP 8.1 but want to install to a PHP 8.3 instance, for example.
+        //       However, this test isn't very portable, and won't run in CI, so we could do with improving this later.
+        $phpConfigPath = '/usr/bin/php-config8.3';
+
+        if (! file_exists($phpConfigPath) || ! is_executable($phpConfigPath)) {
+            self::markTestSkipped('This test can only run where "' . $phpConfigPath . '" exists and is executable, to target PHP 8.3');
+        }
+
+        $this->commandTester->execute([
+            '--with-php-config' => $phpConfigPath,
+            'requested-package-and-version' => $requestedVersion,
+        ]);
+
+        $this->commandTester->assertCommandIsSuccessful();
+
+        $outputString = $this->commandTester->getDisplay();
+        self::assertStringContainsString('Found package: ' . $expectedVersion . ' which provides', $outputString);
+        self::assertStringContainsString('Configure complete with options: --with-php-config=', $outputString);
+        self::assertStringContainsString('Install complete.', $outputString);
+    }
+
+    #[DataProvider('validVersionsList')]
+    public function testInstallingWithPhpPath(string $requestedVersion, string $expectedVersion): void
+    {
+        // @todo This test makes an assumption you're using `ppa:ondrej/php` to have multiple PHP versions. This allows
+        //       us to test scenarios where you run with PHP 8.1 but want to install to a PHP 8.3 instance, for example.
+        //       However, this test isn't very portable, and won't run in CI, so we could do with improving this later.
+        $phpBinaryPath = '/usr/bin/php8.3';
+
+        if (! file_exists($phpBinaryPath) || ! is_executable($phpBinaryPath)) {
+            self::markTestSkipped('This test can only run where "' . $phpBinaryPath . '" exists and is executable, to target PHP 8.3');
+        }
+
+        $this->commandTester->execute([
+            '--with-php-path' => $phpBinaryPath,
+            'requested-package-and-version' => $requestedVersion,
+        ]);
+
+        $this->commandTester->assertCommandIsSuccessful();
+
+        $outputString = $this->commandTester->getDisplay();
+        self::assertStringContainsString('Found package: ' . $expectedVersion . ' which provides', $outputString);
+        self::assertStringContainsString('Install complete.', $outputString);
+    }
+
+    public function testInstallCommandFailsWhenUsingIncompatiblePhpVersion(): void
+    {
+        if (PHP_VERSION_ID >= 80200) {
+            self::markTestSkipped('This test can only run on older than PHP 8.2 - you are running ' . PHP_VERSION);
+        }
+
+        $this->expectException(UnableToResolveRequirement::class);
+        // 1.0.0 is only compatible with PHP 8.3.0
+        $this->commandTester->execute(['requested-package-and-version' => self::TEST_PACKAGE . ':1.0.0']);
+    }
+}

--- a/test/integration/Command/InstallCommandTest.php
+++ b/test/integration/Command/InstallCommandTest.php
@@ -9,6 +9,7 @@ use Php\Pie\Container;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 
 use function array_key_exists;
@@ -35,6 +36,12 @@ class InstallCommandTest extends TestCase
     {
         if (PHP_VERSION_ID < 80300 || PHP_VERSION_ID >= 80400) {
             self::markTestSkipped('This test can only run on PHP 8.3 - you are running ' . PHP_VERSION);
+        }
+
+        try {
+            (new Process(['sudo', 'ls']))->mustRun();
+        } catch (ProcessFailedException) {
+            self::markTestSkipped('Skipping as cannot run with sudo enabled');
         }
 
         $this->commandTester->execute(['requested-package-and-version' => self::TEST_PACKAGE]);

--- a/test/integration/Installing/UnixInstallTest.php
+++ b/test/integration/Installing/UnixInstallTest.php
@@ -20,7 +20,6 @@ use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Process\Process;
 
-/** @covers \Php\Pie\Installing\UnixInstall */
 #[CoversClass(UnixInstall::class)]
 final class UnixInstallTest extends TestCase
 {

--- a/test/integration/Installing/UnixInstallTest.php
+++ b/test/integration/Installing/UnixInstallTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 
 #[CoversClass(UnixInstall::class)]
@@ -29,6 +30,12 @@ final class UnixInstallTest extends TestCase
     {
         if (Platform::isWindows()) {
             self::markTestSkipped('Unix build test cannot be run on Windows');
+        }
+
+        try {
+            (new Process(['sudo', 'ls']))->mustRun();
+        } catch (ProcessFailedException) {
+            self::markTestSkipped('Skipping as cannot run with sudo enabled');
         }
 
         $output         = new BufferedOutput();

--- a/test/integration/Installing/UnixInstallTest.php
+++ b/test/integration/Installing/UnixInstallTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\PieIntegrationTest\Installing;
+
+use Composer\Util\Platform;
+use Php\Pie\Building\UnixBuild;
+use Php\Pie\ConfigureOption;
+use Php\Pie\DependencyResolver\Package;
+use Php\Pie\Downloading\DownloadedPackage;
+use Php\Pie\ExtensionName;
+use Php\Pie\ExtensionType;
+use Php\Pie\Installing\UnixInstall;
+use Php\Pie\Platform\TargetPhp\PhpBinaryPath;
+use Php\Pie\Platform\TargetPlatform;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Process\Process;
+
+/** @covers \Php\Pie\Installing\UnixInstall */
+#[CoversClass(UnixInstall::class)]
+final class UnixInstallTest extends TestCase
+{
+    private const TEST_EXTENSION_PATH = __DIR__ . '/../../assets/pie_test_ext';
+
+    public function testUnixInstallCanInstallExtension(): void
+    {
+        if (Platform::isWindows()) {
+            self::markTestSkipped('Unix build test cannot be run on Windows');
+        }
+
+        $output = new BufferedOutput();
+        $targetPlatform = TargetPlatform::fromPhpBinaryPath(PhpBinaryPath::fromCurrentProcess());
+
+        $downloadedPackage = DownloadedPackage::fromPackageAndExtractedPath(
+            new Package(
+                ExtensionType::PhpModule,
+                ExtensionName::normaliseFromString('pie_test_ext'),
+                'pie_test_ext',
+                '0.1.0',
+                null,
+                [ConfigureOption::fromComposerJsonDefinition(['name' => 'enable-pie_test_ext'])],
+            ),
+            self::TEST_EXTENSION_PATH,
+        );
+
+        (new UnixBuild())->__invoke(
+            $downloadedPackage,
+            $targetPlatform,
+            ['--enable-pie_test_ext'],
+            new NullOutput(),
+        );
+
+        (new UnixInstall())->__invoke(
+            $downloadedPackage,
+            $targetPlatform,
+            $output,
+        );
+
+        $outputString = $output->fetch();
+
+        self::assertStringContainsString('Install complete.', $outputString);
+        self::assertStringContainsString('You must now add "extension=pie_test_ext.so" to your php.ini', $outputString);
+
+        (new Process(['make', 'clean'], $downloadedPackage->extractedSourcePath))->mustRun();
+        (new Process(['phpize', '--clean'], $downloadedPackage->extractedSourcePath))->mustRun();
+    }
+}

--- a/test/integration/Installing/UnixInstallTest.php
+++ b/test/integration/Installing/UnixInstallTest.php
@@ -70,7 +70,7 @@ final class UnixInstallTest extends TestCase
         $outputString = $output->fetch();
 
         self::assertStringContainsString('Install complete: ' . $extensionPath . '/pie_test_ext.so', $outputString);
-        self::assertStringContainsString('You must now add "extension=pie_test_ext.so" to your php.ini', $outputString);
+        self::assertStringContainsString('You must now add "extension=pie_test_ext" to your php.ini', $outputString);
 
         self::assertSame($extensionPath . '/pie_test_ext.so', $installedSharedObject);
         self::assertFileExists($installedSharedObject);

--- a/test/integration/Installing/WindowsInstallTest.php
+++ b/test/integration/Installing/WindowsInstallTest.php
@@ -4,17 +4,83 @@ declare(strict_types=1);
 
 namespace Php\PieIntegrationTest\Installing;
 
+use Composer\Util\Platform;
+use Php\Pie\DependencyResolver\Package;
+use Php\Pie\Downloading\DownloadedPackage;
+use Php\Pie\ExtensionName;
+use Php\Pie\ExtensionType;
 use Php\Pie\Installing\WindowsInstall;
+use Php\Pie\Platform\Architecture;
+use Php\Pie\Platform\OperatingSystem;
+use Php\Pie\Platform\TargetPhp\PhpBinaryPath;
+use Php\Pie\Platform\TargetPlatform;
+use Php\Pie\Platform\ThreadSafetyMode;
+use Php\Pie\Platform\WindowsCompiler;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Process\Process;
+
+use function dirname;
+use function str_replace;
+
+use const DIRECTORY_SEPARATOR;
 
 #[CoversClass(WindowsInstall::class)]
 final class WindowsInstallTest extends TestCase
 {
-    private const TEST_EXTENSION_PATH = __DIR__ . '/../../assets/pie_test_ext';
+    private const TEST_EXTENSION_PATH = __DIR__ . '/../../assets/pie_test_ext_win';
 
     public function testWindowsInstallCanInstallExtension(): void
     {
-        self::markTestIncomplete(__METHOD__ . ' - to be implemented');
+        if (! Platform::isWindows()) {
+            self::markTestSkipped('Test can only be run on Windows');
+        }
+
+        $downloadedPackage = DownloadedPackage::fromPackageAndExtractedPath(
+            new Package(
+                ExtensionType::PhpModule,
+                ExtensionName::normaliseFromString('pie_test_ext'),
+                'php/pie-test-ext',
+                '1.2.3',
+                null,
+                [],
+            ),
+            self::TEST_EXTENSION_PATH,
+        );
+        $output            = new BufferedOutput();
+        $targetPlatform    = new TargetPlatform(
+            OperatingSystem::Windows,
+            PhpBinaryPath::fromCurrentProcess(),
+            Architecture::x86_64,
+            ThreadSafetyMode::ThreadSafe,
+            WindowsCompiler::VS16,
+        );
+        $phpPath           = dirname($targetPlatform->phpBinaryPath->phpBinaryPath);
+        $extensionPath     = $targetPlatform->phpBinaryPath->extensionPath();
+
+        $installer = new WindowsInstall();
+
+        $installedDll = $installer->__invoke($downloadedPackage, $targetPlatform, $output);
+        self::assertSame($extensionPath . '\php_pie_test_ext.dll', $installedDll);
+
+        $outputString = $output->fetch();
+
+        self::assertStringContainsString('Copied DLL to: ' . $extensionPath . '\php_pie_test_ext.dll', $outputString);
+        self::assertStringContainsString('You must now add "extension=pie_test_ext" to your php.ini', $outputString);
+
+        $expectedPdb                 = str_replace('.dll', '.pdb', $installedDll);
+        $expectedSupportingDll       = $phpPath . DIRECTORY_SEPARATOR . 'supporting-library.dll';
+        $expectedSupportingOtherFile = $phpPath . DIRECTORY_SEPARATOR . 'extras' . DIRECTORY_SEPARATOR . 'pie_test_ext' . DIRECTORY_SEPARATOR . 'README.md';
+
+        self::assertFileExists($installedDll);
+        self::assertFileExists($expectedPdb);
+        self::assertFileExists($expectedSupportingDll);
+        self::assertFileExists($expectedSupportingOtherFile);
+
+        (new Process(['del', $installedDll]))->mustRun();
+        (new Process(['del', $expectedPdb]))->mustRun();
+        (new Process(['del', $expectedSupportingDll]))->mustRun();
+        (new Process(['del', $expectedSupportingOtherFile]))->mustRun();
     }
 }

--- a/test/integration/Installing/WindowsInstallTest.php
+++ b/test/integration/Installing/WindowsInstallTest.php
@@ -69,18 +69,22 @@ final class WindowsInstallTest extends TestCase
         self::assertStringContainsString('Copied DLL to: ' . $extensionPath . '\php_pie_test_ext.dll', $outputString);
         self::assertStringContainsString('You must now add "extension=pie_test_ext" to your php.ini', $outputString);
 
+        $extrasDirectory = $phpPath . DIRECTORY_SEPARATOR . 'extras' . DIRECTORY_SEPARATOR . 'pie_test_ext';
+
         $expectedPdb                 = str_replace('.dll', '.pdb', $installedDll);
         $expectedSupportingDll       = $phpPath . DIRECTORY_SEPARATOR . 'supporting-library.dll';
-        $expectedSupportingOtherFile = $phpPath . DIRECTORY_SEPARATOR . 'extras' . DIRECTORY_SEPARATOR . 'pie_test_ext' . DIRECTORY_SEPARATOR . 'README.md';
+        $expectedSupportingOtherFile = $extrasDirectory . DIRECTORY_SEPARATOR . 'README.md';
+        $expectedSubdirectoryFile    = $extrasDirectory . DIRECTORY_SEPARATOR . 'more' . DIRECTORY_SEPARATOR . 'more-information.txt';
 
         self::assertFileExists($installedDll);
         self::assertFileExists($expectedPdb);
         self::assertFileExists($expectedSupportingDll);
         self::assertFileExists($expectedSupportingOtherFile);
+        self::assertFileExists($expectedSubdirectoryFile);
 
         (new Process(['del', $installedDll]))->mustRun();
         (new Process(['del', $expectedPdb]))->mustRun();
         (new Process(['del', $expectedSupportingDll]))->mustRun();
-        (new Process(['del', $expectedSupportingOtherFile]))->mustRun();
+        (new Process(['del', $extrasDirectory]))->mustRun();
     }
 }

--- a/test/integration/Installing/WindowsInstallTest.php
+++ b/test/integration/Installing/WindowsInstallTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\PieIntegrationTest\Installing;
+
+use Php\Pie\Installing\WindowsInstall;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(WindowsInstall::class)]
+final class WindowsInstallTest extends TestCase
+{
+    private const TEST_EXTENSION_PATH = __DIR__ . '/../../assets/pie_test_ext';
+
+    public function testWindowsInstallCanInstallExtension(): void
+    {
+        self::markTestIncomplete(__METHOD__ . ' - to be implemented');
+    }
+}

--- a/test/integration/Installing/WindowsInstallTest.php
+++ b/test/integration/Installing/WindowsInstallTest.php
@@ -82,9 +82,12 @@ final class WindowsInstallTest extends TestCase
         self::assertFileExists($expectedSupportingOtherFile);
         self::assertFileExists($expectedSubdirectoryFile);
 
-        (new Process(['del', $installedDll]))->mustRun();
-        (new Process(['del', $expectedPdb]))->mustRun();
-        (new Process(['del', $expectedSupportingDll]))->mustRun();
-        (new Process(['del', $extrasDirectory]))->mustRun();
+        (new Process(['del', '/Q', $installedDll]))->mustRun();
+        (new Process(['del', '/Q', $expectedPdb]))->mustRun();
+        (new Process(['del', '/Q', $expectedSupportingDll]))->mustRun();
+        // @todo remove this
+//        if (file_exists($extrasDirectory)) {
+//            (new Process(['rmdir', $extrasDirectory]))->mustRun();
+//        }
     }
 }

--- a/test/unit/Command/CommandHelperTest.php
+++ b/test/unit/Command/CommandHelperTest.php
@@ -13,6 +13,7 @@ use Php\Pie\DependencyResolver\Package;
 use Php\Pie\Downloading\DownloadAndExtract;
 use Php\Pie\Downloading\DownloadedPackage;
 use Php\Pie\ExtensionName;
+use Php\Pie\ExtensionType;
 use Php\Pie\Platform\TargetPhp\PhpBinaryPath;
 use Php\Pie\Platform\TargetPlatform;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -102,6 +103,7 @@ final class CommandHelperTest extends TestCase
                 $targetPlatform,
             )
             ->willReturn($package = new Package(
+                ExtensionType::PhpModule,
                 ExtensionName::normaliseFromString('test_pie_ext'),
                 'php/test-pie-ext',
                 '1.2.3',
@@ -141,6 +143,7 @@ final class CommandHelperTest extends TestCase
     public function testProcessingConfigureOptionsFromInput(): void
     {
         $package         = new Package(
+            ExtensionType::PhpModule,
             ExtensionName::normaliseFromString('lolz'),
             'foo/bar',
             '1.0.0',

--- a/test/unit/Downloading/AddAuthenticationHeaderTest.php
+++ b/test/unit/Downloading/AddAuthenticationHeaderTest.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Psr7\Request;
 use Php\Pie\DependencyResolver\Package;
 use Php\Pie\Downloading\AddAuthenticationHeader;
 use Php\Pie\ExtensionName;
+use Php\Pie\ExtensionType;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -33,6 +34,7 @@ final class AddAuthenticationHeaderTest extends TestCase
         $requestWithAuthHeader = (new AddAuthenticationHeader())->withAuthHeaderFromComposer(
             $request,
             new Package(
+                ExtensionType::PhpModule,
                 ExtensionName::normaliseFromString('foo'),
                 'foo/bar',
                 '1.2.3',
@@ -55,6 +57,7 @@ final class AddAuthenticationHeaderTest extends TestCase
 
         $addAuthenticationHeader = new AddAuthenticationHeader();
         $package                 = new Package(
+            ExtensionType::PhpModule,
             ExtensionName::normaliseFromString('foo'),
             'foo/bar',
             '1.2.3',

--- a/test/unit/Downloading/DownloadedPackageTest.php
+++ b/test/unit/Downloading/DownloadedPackageTest.php
@@ -7,6 +7,7 @@ namespace Php\PieUnitTest\Downloading;
 use Php\Pie\DependencyResolver\Package;
 use Php\Pie\Downloading\DownloadedPackage;
 use Php\Pie\ExtensionName;
+use Php\Pie\ExtensionType;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -18,6 +19,7 @@ final class DownloadedPackageTest extends TestCase
     public function testFromPackageAndExtractedPath(): void
     {
         $package = new Package(
+            ExtensionType::PhpModule,
             ExtensionName::normaliseFromString('foo'),
             'foo/bar',
             '1.2.3',

--- a/test/unit/Downloading/Exception/CouldNotFindReleaseAssetTest.php
+++ b/test/unit/Downloading/Exception/CouldNotFindReleaseAssetTest.php
@@ -7,6 +7,7 @@ namespace Php\PieUnitTest\Downloading\Exception;
 use Php\Pie\DependencyResolver\Package;
 use Php\Pie\Downloading\Exception\CouldNotFindReleaseAsset;
 use Php\Pie\ExtensionName;
+use Php\Pie\ExtensionType;
 use Php\Pie\Platform\Architecture;
 use Php\Pie\Platform\OperatingSystem;
 use Php\Pie\Platform\TargetPhp\PhpBinaryPath;
@@ -21,6 +22,7 @@ final class CouldNotFindReleaseAssetTest extends TestCase
     public function testForPackage(): void
     {
         $package = new Package(
+            ExtensionType::PhpModule,
             ExtensionName::normaliseFromString('foo'),
             'foo/bar',
             '1.2.3',
@@ -36,6 +38,7 @@ final class CouldNotFindReleaseAssetTest extends TestCase
     public function testForPackageWithMissingTag(): void
     {
         $package = new Package(
+            ExtensionType::PhpModule,
             ExtensionName::normaliseFromString('foo'),
             'foo/bar',
             '1.2.3',

--- a/test/unit/Downloading/GithubPackageReleaseAssetsTest.php
+++ b/test/unit/Downloading/GithubPackageReleaseAssetsTest.php
@@ -13,6 +13,7 @@ use Php\Pie\DependencyResolver\Package;
 use Php\Pie\Downloading\Exception\CouldNotFindReleaseAsset;
 use Php\Pie\Downloading\GithubPackageReleaseAssets;
 use Php\Pie\ExtensionName;
+use Php\Pie\ExtensionType;
 use Php\Pie\Platform\Architecture;
 use Php\Pie\Platform\OperatingSystem;
 use Php\Pie\Platform\TargetPhp\PhpBinaryPath;
@@ -67,6 +68,7 @@ final class GithubPackageReleaseAssetsTest extends TestCase
         $guzzleMockClient = new Client(['handler' => HandlerStack::create($mockHandler)]);
 
         $package = new Package(
+            ExtensionType::PhpModule,
             ExtensionName::normaliseFromString('foo'),
             'asgrim/example-pie-extension',
             '1.2.3',
@@ -118,6 +120,7 @@ final class GithubPackageReleaseAssetsTest extends TestCase
         $guzzleMockClient = new Client(['handler' => HandlerStack::create($mockHandler)]);
 
         $package = new Package(
+            ExtensionType::PhpModule,
             ExtensionName::normaliseFromString('foo'),
             'asgrim/example-pie-extension',
             '1.2.3',
@@ -155,6 +158,7 @@ final class GithubPackageReleaseAssetsTest extends TestCase
         $guzzleMockClient = new Client(['handler' => HandlerStack::create($mockHandler)]);
 
         $package = new Package(
+            ExtensionType::PhpModule,
             ExtensionName::normaliseFromString('foo'),
             'asgrim/example-pie-extension',
             '1.2.3',

--- a/test/unit/Downloading/UnixDownloadAndExtractTest.php
+++ b/test/unit/Downloading/UnixDownloadAndExtractTest.php
@@ -10,6 +10,7 @@ use Php\Pie\Downloading\DownloadZip;
 use Php\Pie\Downloading\ExtractZip;
 use Php\Pie\Downloading\UnixDownloadAndExtract;
 use Php\Pie\ExtensionName;
+use Php\Pie\ExtensionType;
 use Php\Pie\Platform\Architecture;
 use Php\Pie\Platform\OperatingSystem;
 use Php\Pie\Platform\TargetPhp\PhpBinaryPath;
@@ -60,6 +61,7 @@ final class UnixDownloadAndExtractTest extends TestCase
 
         $downloadUrl      = 'https://test-uri/' . uniqid('downloadUrl', true);
         $requestedPackage = new Package(
+            ExtensionType::PhpModule,
             ExtensionName::normaliseFromString('foo'),
             'foo/bar',
             '1.2.3',

--- a/test/unit/Downloading/WindowsDownloadAndExtractTest.php
+++ b/test/unit/Downloading/WindowsDownloadAndExtractTest.php
@@ -11,6 +11,7 @@ use Php\Pie\Downloading\ExtractZip;
 use Php\Pie\Downloading\PackageReleaseAssets;
 use Php\Pie\Downloading\WindowsDownloadAndExtract;
 use Php\Pie\ExtensionName;
+use Php\Pie\ExtensionType;
 use Php\Pie\Platform\Architecture;
 use Php\Pie\Platform\OperatingSystem;
 use Php\Pie\Platform\TargetPhp\PhpBinaryPath;
@@ -75,6 +76,7 @@ final class WindowsDownloadAndExtractTest extends TestCase
             ->willReturn($extractedPath);
 
         $requestedPackage = new Package(
+            ExtensionType::PhpModule,
             ExtensionName::normaliseFromString('foo'),
             'foo/bar',
             '1.2.3',

--- a/test/unit/ExtensionTypeTest.php
+++ b/test/unit/ExtensionTypeTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\PieUnitTest;
+
+use Php\Pie\ExtensionType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ExtensionType::class)]
+final class ExtensionTypeTest extends TestCase
+{
+    public function testIsValid(): void
+    {
+        self::assertTrue(ExtensionType::isValid('php-ext'));
+        self::assertTrue(ExtensionType::isValid('php-ext-zend'));
+        self::assertFalse(ExtensionType::isValid('project'));
+        self::assertFalse(ExtensionType::isValid('library'));
+        self::assertFalse(ExtensionType::isValid('metapackage'));
+        self::assertFalse(ExtensionType::isValid('composer-plugin'));
+    }
+}

--- a/test/unit/Platform/TargetPhp/PhpBinaryPathTest.php
+++ b/test/unit/Platform/TargetPhp/PhpBinaryPathTest.php
@@ -128,6 +128,7 @@ final class PhpBinaryPathTest extends TestCase
 
     public function testExtensionPath(): void
     {
+        // @todo test relative `ext` path on Windows
         self::assertSame(
             ini_get('extension_dir'),
             PhpBinaryPath::fromCurrentProcess()

--- a/test/unit/Platform/TargetPhp/PhpBinaryPathTest.php
+++ b/test/unit/Platform/TargetPhp/PhpBinaryPathTest.php
@@ -128,11 +128,21 @@ final class PhpBinaryPathTest extends TestCase
 
     public function testExtensionPath(): void
     {
-        // @todo test relative `ext` path on Windows
+        $phpBinary = PhpBinaryPath::fromCurrentProcess();
+
+        $expectedExtensionDir = ini_get('extension_dir');
+
+        // `extension_dir` may be a relative URL on Windows (e.g. "ext"), so resolve it according to the location of PHP
+        if (!file_exists($expectedExtensionDir) || !is_dir($expectedExtensionDir)) {
+            $absoluteExtensionDir = dirname($phpBinary->phpBinaryPath) . DIRECTORY_SEPARATOR . $expectedExtensionDir;
+            if (file_exists($absoluteExtensionDir) && is_dir($absoluteExtensionDir)) {
+                $expectedExtensionDir = $absoluteExtensionDir;
+            }
+        }
+
         self::assertSame(
-            ini_get('extension_dir'),
-            PhpBinaryPath::fromCurrentProcess()
-                ->extensionPath(),
+            $expectedExtensionDir,
+            $phpBinary->extensionPath(),
         );
     }
 }

--- a/test/unit/Platform/TargetPhp/PhpBinaryPathTest.php
+++ b/test/unit/Platform/TargetPhp/PhpBinaryPathTest.php
@@ -17,6 +17,7 @@ use function assert;
 use function defined;
 use function file_exists;
 use function get_loaded_extensions;
+use function ini_get;
 use function is_executable;
 use function php_uname;
 use function phpversion;
@@ -122,6 +123,15 @@ final class PhpBinaryPathTest extends TestCase
             PHP_INT_SIZE,
             PhpBinaryPath::fromCurrentProcess()
                 ->phpIntSize(),
+        );
+    }
+
+    public function testExtensionPath(): void
+    {
+        self::assertSame(
+            ini_get('extension_dir'),
+            PhpBinaryPath::fromCurrentProcess()
+                ->extensionPath(),
         );
     }
 }

--- a/test/unit/Platform/TargetPhp/PhpBinaryPathTest.php
+++ b/test/unit/Platform/TargetPhp/PhpBinaryPathTest.php
@@ -15,15 +15,18 @@ use function array_combine;
 use function array_map;
 use function assert;
 use function defined;
+use function dirname;
 use function file_exists;
 use function get_loaded_extensions;
 use function ini_get;
+use function is_dir;
 use function is_executable;
 use function php_uname;
 use function phpversion;
 use function sprintf;
 use function trim;
 
+use const DIRECTORY_SEPARATOR;
 use const PHP_INT_SIZE;
 use const PHP_MAJOR_VERSION;
 use const PHP_MINOR_VERSION;
@@ -133,7 +136,7 @@ final class PhpBinaryPathTest extends TestCase
         $expectedExtensionDir = ini_get('extension_dir');
 
         // `extension_dir` may be a relative URL on Windows (e.g. "ext"), so resolve it according to the location of PHP
-        if (!file_exists($expectedExtensionDir) || !is_dir($expectedExtensionDir)) {
+        if (! file_exists($expectedExtensionDir) || ! is_dir($expectedExtensionDir)) {
             $absoluteExtensionDir = dirname($phpBinary->phpBinaryPath) . DIRECTORY_SEPARATOR . $expectedExtensionDir;
             if (file_exists($absoluteExtensionDir) && is_dir($absoluteExtensionDir)) {
                 $expectedExtensionDir = $absoluteExtensionDir;

--- a/test/unit/Platform/WindowsExtensionAssetNameTest.php
+++ b/test/unit/Platform/WindowsExtensionAssetNameTest.php
@@ -22,6 +22,7 @@ final class WindowsExtensionAssetNameTest extends TestCase
 {
     private TargetPlatform $platform;
     private Package $package;
+    private string $phpVersion;
 
     public function setUp(): void
     {
@@ -34,6 +35,8 @@ final class WindowsExtensionAssetNameTest extends TestCase
             ThreadSafetyMode::ThreadSafe,
             WindowsCompiler::VC14,
         );
+
+        $this->phpVersion = $this->platform->phpBinaryPath->majorMinorVersion();
 
         $this->package = new Package(
             ExtensionType::PhpModule,
@@ -49,8 +52,8 @@ final class WindowsExtensionAssetNameTest extends TestCase
     {
         self::assertSame(
             [
-                'php_foo-1.2.3-8.3-ts-vc14-x86_64.zip',
-                'php_foo-1.2.3-8.3-vc14-ts-x86_64.zip',
+                'php_foo-1.2.3-' . $this->phpVersion . '-ts-vc14-x86_64.zip',
+                'php_foo-1.2.3-' . $this->phpVersion . '-vc14-ts-x86_64.zip',
             ],
             WindowsExtensionAssetName::zipNames($this->platform, $this->package),
         );
@@ -60,8 +63,8 @@ final class WindowsExtensionAssetNameTest extends TestCase
     {
         self::assertSame(
             [
-                'php_foo-1.2.3-8.3-ts-vc14-x86_64.dll',
-                'php_foo-1.2.3-8.3-vc14-ts-x86_64.dll',
+                'php_foo-1.2.3-' . $this->phpVersion . '-ts-vc14-x86_64.dll',
+                'php_foo-1.2.3-' . $this->phpVersion . '-vc14-ts-x86_64.dll',
             ],
             WindowsExtensionAssetName::dllNames($this->platform, $this->package),
         );

--- a/test/unit/Platform/WindowsExtensionAssetNameTest.php
+++ b/test/unit/Platform/WindowsExtensionAssetNameTest.php
@@ -20,16 +20,22 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(WindowsExtensionAssetName::class)]
 final class WindowsExtensionAssetNameTest extends TestCase
 {
-    public function testZipNames(): void
+    private TargetPlatform $platform;
+    private Package $package;
+
+    public function setUp(): void
     {
-        $platform = new TargetPlatform(
+        parent::setUp();
+
+        $this->platform = new TargetPlatform(
             OperatingSystem::Windows,
             PhpBinaryPath::fromCurrentProcess(),
             Architecture::x86_64,
             ThreadSafetyMode::ThreadSafe,
             WindowsCompiler::VC14,
         );
-        $package  = new Package(
+
+        $this->package = new Package(
             ExtensionType::PhpModule,
             ExtensionName::normaliseFromString('foo'),
             'phpf/foo',
@@ -37,13 +43,27 @@ final class WindowsExtensionAssetNameTest extends TestCase
             null,
             [],
         );
+    }
 
+    public function testZipNames(): void
+    {
         self::assertSame(
             [
                 'php_foo-1.2.3-8.3-ts-vc14-x86_64.zip',
                 'php_foo-1.2.3-8.3-vc14-ts-x86_64.zip',
             ],
-            WindowsExtensionAssetName::zipNames($platform, $package),
+            WindowsExtensionAssetName::zipNames($this->platform, $this->package),
+        );
+    }
+
+    public function testDllNames(): void
+    {
+        self::assertSame(
+            [
+                'php_foo-1.2.3-8.3-ts-vc14-x86_64.dll',
+                'php_foo-1.2.3-8.3-vc14-ts-x86_64.dll',
+            ],
+            WindowsExtensionAssetName::dllNames($this->platform, $this->package),
         );
     }
 }

--- a/test/unit/Platform/WindowsExtensionAssetNameTest.php
+++ b/test/unit/Platform/WindowsExtensionAssetNameTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\PieUnitTest\Platform;
+
+use Php\Pie\DependencyResolver\Package;
+use Php\Pie\ExtensionName;
+use Php\Pie\ExtensionType;
+use Php\Pie\Platform\Architecture;
+use Php\Pie\Platform\OperatingSystem;
+use Php\Pie\Platform\TargetPhp\PhpBinaryPath;
+use Php\Pie\Platform\TargetPlatform;
+use Php\Pie\Platform\ThreadSafetyMode;
+use Php\Pie\Platform\WindowsCompiler;
+use Php\Pie\Platform\WindowsExtensionAssetName;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(WindowsExtensionAssetName::class)]
+final class WindowsExtensionAssetNameTest extends TestCase
+{
+    public function testZipNames(): void
+    {
+        $platform = new TargetPlatform(
+            OperatingSystem::Windows,
+            PhpBinaryPath::fromCurrentProcess(),
+            Architecture::x86_64,
+            ThreadSafetyMode::ThreadSafe,
+            WindowsCompiler::VC14,
+        );
+        $package  = new Package(
+            ExtensionType::PhpModule,
+            ExtensionName::normaliseFromString('foo'),
+            'phpf/foo',
+            '1.2.3',
+            null,
+            [],
+        );
+
+        self::assertSame(
+            [
+                'php_foo-1.2.3-8.3-ts-vc14-x86_64.zip',
+                'php_foo-1.2.3-8.3-vc14-ts-x86_64.zip',
+            ],
+            WindowsExtensionAssetName::zipNames($platform, $package),
+        );
+    }
+}


### PR DESCRIPTION
Fixes #4

# Are you an end user who would like to try this out?

Please note that this is just an initial implementation, and you should definitely not run this anywhere near a production system just yet.

**If you understand, and you'd still like to help test this...**

Primarily the best way to provide feedback here as an end user of PIE is to check the `install` command works on your machine! You can do that by following these steps (please adjust for your platform differences of course!)

 * Ensure you are using **PHP 8.3** (this is because my test extension `asgrim/example-pie-extension` is intentionally only compatible with PHP 8.3)
 * `git clone -b install-command-implementation https://github.com/asgrim/pie.git`
 * `composer install`
 * `bin/pie install asgrim/example-pie-extension`
 * Let me know if you encounter any errors or something unexpected!

You should see something like:

```
$ bin/pie install asgrim/example-pie-extension
This command needs elevated privileges, and may prompt you for your password.
You are running PHP 8.3.9
Target PHP installation: 8.3.9 nts, on Linux/OSX/etc x86_64 (from /usr/bin/php8.3)
Found package: asgrim/example-pie-extension:1.0.1 which provides ext-example_pie_extension
phpize complete.
Configure complete.
Build complete: /tmp/pie_downloader_669e733fcc5f73.59699730/asgrim-example-pie-extension-769f906/modules/example_pie_extension.so
[sudo] password for youruser: 
Install complete: /usr/lib/php/20230831/example_pie_extension.so
You must now add "extension=example_pie_extension" to your php.ini
```

Or on Windows:

```
>C:\php-8.3.6\php.exe bin/pie install asgrim/example-pie-extension
This command needs elevated privileges, and may prompt you for your password.
You are running PHP 8.3.6
Target PHP installation: 8.3.6 ts, vs16, on Windows x86_64 (from C:\php-8.3.6\php.exe)
Found package: asgrim/example-pie-extension:1.0.1 which provides ext-example_pie_extension
Nothing to do on Windows.
Copied DLL to: C:\php-8.3.6\ext\php_example_pie_extension.dll
Copied PDB to: C:\php-8.3.6\ext\php_example_pie_extension.pdb
You must now add "extension=example_pie_extension" to your php.ini
```

# Are you an extension maintainer who would like to try this out?

It's not strictly necessary to support this just yet, but if you're keen, and please note, things may change before we finally release PIE... so you do this at your own risk. Note: at the moment, you will need to make a new release - see ThePHPF/pie-design#17

 * Add and commit a `composer.json` to your repo - example here https://github.com/asgrim/example-pie-extension/blob/main/composer.json
 * Make a **release** (`alpha` release is fine, e.g. `1.2.3-alpha.`) - note, "branches" or "commits" are not yet supported - see #13 
 * Then, add it to Packagist here: https://packagist.org/packages/submit (you put the GH URL in, it should detect the `composer.json` automatically and understand that it is a `php-ext` or `php-ext-zend`, it should appear in https://packagist.org/extensions once added

More details, for example for help on `composer.json`, can be read in https://github.com/ThePHPF/pie-design?tab=readme-ov-file#extension-maintainer-register-a-pie-package