### PR TITLE
Removed workaround for no tags existing yet in the repo

### DIFF
--- a/.github/workflows/release-unsigned-phar.yml
+++ b/.github/workflows/release-unsigned-phar.yml
@@ -23,8 +23,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      # Temporary until we have a first tag; Box needs at least one tag to exist!
-      - run: git describe --tags HEAD || git tag 0.0.0
       - uses: ramsey/composer-install@v3
       - name: Build PHAR
         run: box compile


### PR DESCRIPTION
Now we have our first tag, we shouldn't need to workaround the missing tag :)