### PR TITLE
Fixed getReleaseAssetsForPackage() for repositories with names that do not match the package name.

### DIFF
--- a/src/DependencyResolver/Package.php
+++ b/src/DependencyResolver/Package.php
@@ -11,6 +11,11 @@ use Php\Pie\ExtensionType;
 
 use function array_key_exists;
 use function array_map;
+use function array_slice;
+use function explode;
+use function implode;
+use function parse_url;
+use function str_contains;
 
 /**
  * @internal This is not public API for PIE, so should not be depended upon unless you accept the risk of BC breaks
@@ -70,5 +75,20 @@ final class Package
     public function prettyNameAndVersion(): string
     {
         return $this->name . ':' . $this->version;
+    }
+
+    public function githubRepository(): string
+    {
+        if ($this->downloadUrl === null || str_contains($this->downloadUrl, '/' . $this->name . '/')) {
+            return $this->name;
+        }
+
+        $parsed = parse_url($this->downloadUrl);
+        if ($parsed === false || ! array_key_exists('path', $parsed)) {
+            return $this->name;
+        }
+
+        // Converts https://api.github.com/repos/<user>/<repository>/zipball/<sha>" to "<user>/<repository>"
+        return implode('/', array_slice(explode('/', $parsed['path']), 2, 2));
     }
 }

--- a/src/DependencyResolver/Package.php
+++ b/src/DependencyResolver/Package.php
@@ -16,6 +16,7 @@ use function explode;
 use function implode;
 use function parse_url;
 use function str_contains;
+use function str_starts_with;
 
 /**
  * @internal This is not public API for PIE, so should not be depended upon unless you accept the risk of BC breaks
@@ -77,9 +78,13 @@ final class Package
         return $this->name . ':' . $this->version;
     }
 
-    public function githubRepository(): string
+    public function githubOrgAndRepository(): string
     {
         if ($this->downloadUrl === null || str_contains($this->downloadUrl, '/' . $this->name . '/')) {
+            return $this->name;
+        }
+
+        if (! str_starts_with($this->downloadUrl, 'https://api.github.com/repos/')) {
             return $this->name;
         }
 

--- a/src/Downloading/GithubPackageReleaseAssets.php
+++ b/src/Downloading/GithubPackageReleaseAssets.php
@@ -76,9 +76,8 @@ final class GithubPackageReleaseAssets implements PackageReleaseAssets
     /** @return list<array{name: non-empty-string, browser_download_url: non-empty-string, ...}> */
     private function getReleaseAssetsForPackage(Package $package): array
     {
-        // @todo confirm prettyName will always match the repo name - it might not
         $request = AddAuthenticationHeader::withAuthHeaderFromComposer(
-            new Request('GET', $this->githubApiBaseUrl . '/repos/' . $package->name . '/releases/tags/' . $package->version),
+            new Request('GET', $this->githubApiBaseUrl . '/repos/' . $package->githubRepository() . '/releases/tags/' . $package->version),
             $package,
             $this->authHelper,
         );

--- a/src/Downloading/GithubPackageReleaseAssets.php
+++ b/src/Downloading/GithubPackageReleaseAssets.php
@@ -77,7 +77,7 @@ final class GithubPackageReleaseAssets implements PackageReleaseAssets
     private function getReleaseAssetsForPackage(Package $package): array
     {
         $request = AddAuthenticationHeader::withAuthHeaderFromComposer(
-            new Request('GET', $this->githubApiBaseUrl . '/repos/' . $package->githubRepository() . '/releases/tags/' . $package->version),
+            new Request('GET', $this->githubApiBaseUrl . '/repos/' . $package->githubOrgAndRepository() . '/releases/tags/' . $package->version),
             $package,
             $this->authHelper,
         );


### PR DESCRIPTION
Fixes #68

I'm not sure if this is the correct approach, but this was made in an attempt to further verify the installation of the `mongodb/mongodb-extension` on Windows.