### PR TITLE
Fixed error in documentation regarding using PIE to install an extension for a different php version

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -71,7 +71,7 @@ On Windows, you may provide a path to the `php` executable itself using the
 to run PIE, but we want to download the extension for PHP 8.3:
 
 ```shell
-> C:\php-8.3.6\php.exe C:\pie.phar install --with-php-path=C:\php-8.1.7\php.exe example/example-pie-extension
+> C:\php-8.1.7\php.exe C:\pie.phar install --with-php-path=C:\php-8.3.6\php.exe example/example-pie-extension
 ```
 
 ### Version constraints and stability


### PR DESCRIPTION
Proof:

```shell
C:\php\php-8.1.30\php.exe bin/pie install --with-php-path=C:\php\php-8.3.12\php.exe mongodb/mongodb-extension
This command may need elevated privileges, and may prompt you for your password.
You are running PHP 8.1.30
Target PHP installation: 8.3.12 ts, vs16, on Windows x86_64 (from C:\php\php-8.3.12\php.exe)
Found package: mongodb/mongodb-extension:1.20.0 which provides ext-mongodb
Nothing to do on Windows.
Copied DLL to: C:\php\php-8.3.12\ext\php_mongodb.dll
Copied PDB to: C:\php\php-8.3.12\ext\php_mongodb.pdb
Copied extras: C:\php\php-8.3.12\extras\mongodb\CONTRIBUTING.md
Copied extras: C:\php\php-8.3.12\extras\mongodb\CREDITS
Copied extras: C:\php\php-8.3.12\extras\mongodb\LICENSE
Copied extras: C:\php\php-8.3.12\extras\mongodb\php_mongodb.dll.sig
Copied extras: C:\php\php-8.3.12\extras\mongodb\README.md
Copied extras: C:\php\php-8.3.12\extras\mongodb\THIRD_PARTY_NOTICES
You must now add "extension=mongodb" to your php.ini
```

I needed this feature because I was unable to update the MongoDB extension. The previously installed extension DLL gets locked by the PHP process running PIE. At that point, updating the extension manually would've been quicker than setting up another version of PHP, but what's the fun in that? 😛 

**Note:** I modified my code locally so that I can actually install `mongodb/mongodb-extension:1.20.0`, this will not work with a prebuilt version of PIE until the format and content of the MongoDB extension package is fixed.