### PR TITLE
Adjust timeouts for invoked processes

### DIFF
--- a/src/Util/Process.php
+++ b/src/Util/Process.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\Pie\Util;
+
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process as SymfonyProcess;
+
+use function trim;
+
+final class Process
+{
+    /** @psalm-suppress UnusedConstructor */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Just a helper to invoke a Symfony Process command with a simplified API
+     * for the common invocations we have in PIE.
+     *
+     * Things to note:
+     *  - uses mustRun (i.e. throws exception if command execution fails)
+     *  - very short timeout by default (5 seconds)
+     *  - output is trimmed
+     *
+     * @param list<string> $command
+     *
+     * @throws ProcessFailedException
+     */
+    public static function run(array $command, string|null $workingDirectory = null, int|null $timeout = 5): string
+    {
+        return trim((new SymfonyProcess($command, $workingDirectory, timeout: $timeout))
+            ->mustRun()
+            ->getOutput());
+    }
+}


### PR DESCRIPTION
Fixes #72 

Defaulted to 5s for all commands executed, except:

 - `phpize` - 1 minute
 - `./configure` - 2 minutes
 - `make` - 10 minutes
 - `make install` - 1 minute

I think these are reasonable maximums, but we can adjust accordingly with the constants defined going forward, should we need to.