### PR TITLE
Parallel jobs with make

### DIFF
--- a/src/Building/UnixBuild.php
+++ b/src/Building/UnixBuild.php
@@ -52,7 +52,7 @@ final class UnixBuild implements Build
         $optionsOutput = count($configureOptions) ? ' with options: ' . implode(' ', $configureOptions) : '.';
         $output->writeln('<info>Configure complete</info>' . $optionsOutput);
 
-        $makeOutput = $this->make($downloadedPackage);
+        $makeOutput = $this->make($targetPlatform, $downloadedPackage);
         if ($output->isVeryVerbose()) {
             $output->writeln($makeOutput);
         }
@@ -93,10 +93,10 @@ final class UnixBuild implements Build
         );
     }
 
-    private function make(DownloadedPackage $downloadedPackage): string
+    private function make(TargetPlatform $targetPlatform, DownloadedPackage $downloadedPackage): string
     {
         return Process::run(
-            ['make'],
+            ['make', '--jobs', $targetPlatform->makeParallelJobs],
             $downloadedPackage->extractedSourcePath,
             self::MAKE_TIMEOUT_SECS,
         );

--- a/src/Building/UnixBuild.php
+++ b/src/Building/UnixBuild.php
@@ -20,7 +20,7 @@ final class UnixBuild implements Build
 {
     private const PHPIZE_TIMEOUT_SECS    = 60; // 1 minute
     private const CONFIGURE_TIMEOUT_SECS = 120; // 2 minutes
-    private const MAKE_TIMEOUT_SECS      = 600; // 10 minutes
+    private const MAKE_TIMEOUT_SECS      = null; // unlimited
 
     /** {@inheritDoc} */
     public function __invoke(
@@ -101,7 +101,7 @@ final class UnixBuild implements Build
             $output->writeln('Running make without parallelization - try providing -jN to PIE where N is the number of cores you have.');
         } else {
             $makeCommand[] = '--jobs';
-            $makeCommand[] = $targetPlatform->makeParallelJobs;
+            $makeCommand[] = (string) $targetPlatform->makeParallelJobs;
         }
 
         return Process::run(

--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -121,11 +121,10 @@ final class CommandHelper
 
         $makeParallelJobs = null; /** `null` means {@see TargetPlatform} will try to auto-detect */
         if ($input->hasOption(self::OPTION_MAKE_PARALLEL_JOBS)) {
-            $makeParallelJobs = (int) $input->getOption(self::OPTION_MAKE_PARALLEL_JOBS);
-            Assert::positiveInteger(
-                $makeParallelJobs,
-                'Expected a positive integer for the --' . self::OPTION_MAKE_PARALLEL_JOBS . ' option. Got: %s',
-            );
+            $makeParallelJobsOptions = (int) $input->getOption(self::OPTION_MAKE_PARALLEL_JOBS);
+            if ($makeParallelJobsOptions > 0) {
+                $makeParallelJobs = $makeParallelJobsOptions;
+            }
         }
 
         $targetPlatform = TargetPlatform::fromPhpBinaryPath($phpBinaryPath, $makeParallelJobs);

--- a/src/Platform/TargetPlatform.php
+++ b/src/Platform/TargetPlatform.php
@@ -6,6 +6,7 @@ namespace Php\Pie\Platform;
 
 use Php\Pie\Platform\TargetPhp\PhpBinaryPath;
 
+use Php\Pie\Util\NumberOfCores;
 use function array_key_exists;
 use function curl_version;
 use function explode;
@@ -124,9 +125,8 @@ class TargetPlatform
         }
 
         if ($makeParallelJobs === null) {
-            $makeParallelJobs = 16; // @todo detect
+            $makeParallelJobs = NumberOfCores::determine();
         }
-
 
         return new self(
             $os,

--- a/src/Platform/TargetPlatform.php
+++ b/src/Platform/TargetPlatform.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Php\Pie\Platform;
 
 use Php\Pie\Platform\TargetPhp\PhpBinaryPath;
-
 use Php\Pie\Util\NumberOfCores;
+
 use function array_key_exists;
 use function curl_version;
 use function explode;

--- a/src/Platform/TargetPlatform.php
+++ b/src/Platform/TargetPlatform.php
@@ -27,6 +27,7 @@ class TargetPlatform
         public readonly PhpBinaryPath $phpBinaryPath,
         public readonly Architecture $architecture,
         public readonly ThreadSafetyMode $threadSafety,
+        public readonly int $makeParallelJobs,
         public readonly WindowsCompiler|null $windowsCompiler,
     ) {
     }
@@ -50,7 +51,7 @@ class TargetPlatform
         return function_exists('posix_getuid') && posix_getuid() === 0;
     }
 
-    public static function fromPhpBinaryPath(PhpBinaryPath $phpBinaryPath): self
+    public static function fromPhpBinaryPath(PhpBinaryPath $phpBinaryPath, int|null $makeParallelJobs): self
     {
         $os = $phpBinaryPath->operatingSystem();
 
@@ -122,11 +123,17 @@ class TargetPlatform
             }
         }
 
+        if ($makeParallelJobs === null) {
+            $makeParallelJobs = 16; // @todo detect
+        }
+
+
         return new self(
             $os,
             $phpBinaryPath,
             $architecture,
             $threadSafety,
+            $makeParallelJobs,
             $windowsCompiler,
         );
     }

--- a/src/Util/NumberOfCores.php
+++ b/src/Util/NumberOfCores.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\Pie\Util;
+
+use Symfony\Component\Process\Process;
+
+final class NumberOfCores
+{
+    /** @psalm-suppress UnusedConstructor */
+    private function __construct()
+    {
+    }
+
+    /**
+     * @param list<string> $params
+     *
+     * @return positive-int
+     */
+    private static function tryCommand(string $command, array $params): int|null
+    {
+        $whichProcess = new Process(['which', $command]);
+        if ($whichProcess->run() === 0) {
+            $commandPath = trim($whichProcess->getOutput());
+
+            $commandProcess = new Process([$commandPath, ...$params]);
+            if ($commandProcess->run() === 0) {
+                $commandResult = trim($commandProcess->getOutput());
+                if (is_numeric($commandResult)) {
+                    $commandNumericResult = (int) $commandResult;
+
+                    if ($commandNumericResult > 0) {
+                        return $commandNumericResult;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Try a few different ways of determining number of CPUs. If we can't guess
+     * how many CPUs someone has, then default to 1 for safety.
+     *
+     * @return positive-int
+     */
+    public static function determine(): int
+    {
+        $nproc = self::tryCommand('nproc', ['--all']);
+        if ($nproc !== null) {
+            return $nproc;
+        }
+
+        $getconf = self::tryCommand('getconf', ['_NPROCESSORS_ONLN']);
+        if ($getconf !== null) {
+            return $getconf;
+        }
+
+        $sysctl = self::tryCommand('sysctl', ['-n', 'hw.ncpu']);
+        if ($sysctl !== null) {
+            return $sysctl;
+        }
+
+        // Default to 1 for safety
+        return 1;
+    }
+}

--- a/src/Util/NumberOfCores.php
+++ b/src/Util/NumberOfCores.php
@@ -6,6 +6,9 @@ namespace Php\Pie\Util;
 
 use Symfony\Component\Process\Process;
 
+use function is_numeric;
+use function trim;
+
 final class NumberOfCores
 {
     /** @psalm-suppress UnusedConstructor */

--- a/test/integration/Building/UnixBuildTest.php
+++ b/test/integration/Building/UnixBuildTest.php
@@ -50,7 +50,7 @@ final class UnixBuildTest extends TestCase
         $unixBuilder = new UnixBuild();
         $unixBuilder->__invoke(
             $downloadedPackage,
-            TargetPlatform::fromPhpBinaryPath(PhpBinaryPath::fromCurrentProcess()),
+            TargetPlatform::fromPhpBinaryPath(PhpBinaryPath::fromCurrentProcess(), null),
             ['--enable-pie_test_ext'],
             $output,
         );

--- a/test/integration/DependencyResolver/ResolveDependencyWithComposerTest.php
+++ b/test/integration/DependencyResolver/ResolveDependencyWithComposerTest.php
@@ -69,7 +69,7 @@ final class ResolveDependencyWithComposerTest extends TestCase
         $resolve   = $container->get(DependencyResolver::class);
 
         $package = $resolve->__invoke(
-            TargetPlatform::fromPhpBinaryPath(PhpBinaryPath::fromCurrentProcess()),
+            TargetPlatform::fromPhpBinaryPath(PhpBinaryPath::fromCurrentProcess(), null),
             'asgrim/example-pie-extension',
             $requestedVersion,
         );

--- a/test/integration/Installing/UnixInstallTest.php
+++ b/test/integration/Installing/UnixInstallTest.php
@@ -75,7 +75,7 @@ final class UnixInstallTest extends TestCase
         }
 
         $output         = new BufferedOutput();
-        $targetPlatform = TargetPlatform::fromPhpBinaryPath(PhpBinaryPath::fromPhpConfigExecutable($phpConfig));
+        $targetPlatform = TargetPlatform::fromPhpBinaryPath(PhpBinaryPath::fromPhpConfigExecutable($phpConfig), null);
         $extensionPath  = $targetPlatform->phpBinaryPath->extensionPath();
 
         $downloadedPackage = DownloadedPackage::fromPackageAndExtractedPath(

--- a/test/integration/Installing/WindowsInstallTest.php
+++ b/test/integration/Installing/WindowsInstallTest.php
@@ -65,6 +65,7 @@ final class WindowsInstallTest extends TestCase
             PhpBinaryPath::fromCurrentProcess(),
             Architecture::x86_64,
             ThreadSafetyMode::ThreadSafe,
+            1,
             WindowsCompiler::VS16,
         );
         $phpPath           = dirname($targetPlatform->phpBinaryPath->phpBinaryPath);

--- a/test/unit/Command/CommandHelperTest.php
+++ b/test/unit/Command/CommandHelperTest.php
@@ -92,7 +92,7 @@ final class CommandHelperTest extends TestCase
     public function testDownloadPackage(): void
     {
         $dependencyResolver          = $this->createMock(DependencyResolver::class);
-        $targetPlatform              = TargetPlatform::fromPhpBinaryPath(PhpBinaryPath::fromCurrentProcess());
+        $targetPlatform              = TargetPlatform::fromPhpBinaryPath(PhpBinaryPath::fromCurrentProcess(), null);
         $requestedNameAndVersionPair = ['name' => 'php/test-pie-ext', 'version' => '^1.2'];
         $downloadAndExtract          = $this->createMock(DownloadAndExtract::class);
         $output                      = $this->createMock(OutputInterface::class);

--- a/test/unit/DependencyResolver/ResolveDependencyWithComposerTest.php
+++ b/test/unit/DependencyResolver/ResolveDependencyWithComposerTest.php
@@ -57,6 +57,7 @@ final class ResolveDependencyWithComposerTest extends TestCase
             $phpBinaryPath,
             Architecture::x86_64,
             ThreadSafetyMode::ThreadSafe,
+            1,
             null,
         );
 
@@ -97,6 +98,7 @@ final class ResolveDependencyWithComposerTest extends TestCase
             $phpBinaryPath,
             Architecture::x86_64,
             ThreadSafetyMode::ThreadSafe,
+            1,
             null,
         );
 
@@ -139,6 +141,7 @@ final class ResolveDependencyWithComposerTest extends TestCase
             $phpBinaryPath,
             Architecture::x86_64,
             ThreadSafetyMode::NonThreadSafe,
+            1,
             null,
         );
 
@@ -181,6 +184,7 @@ final class ResolveDependencyWithComposerTest extends TestCase
             $phpBinaryPath,
             Architecture::x86_64,
             ThreadSafetyMode::ThreadSafe,
+            1,
             null,
         );
 

--- a/test/unit/Downloading/Exception/CouldNotFindReleaseAssetTest.php
+++ b/test/unit/Downloading/Exception/CouldNotFindReleaseAssetTest.php
@@ -67,6 +67,7 @@ final class CouldNotFindReleaseAssetTest extends TestCase
             $phpBinary,
             Architecture::x86,
             ThreadSafetyMode::NonThreadSafe,
+            1,
             null,
         ));
 

--- a/test/unit/Downloading/GithubPackageReleaseAssetsTest.php
+++ b/test/unit/Downloading/GithubPackageReleaseAssetsTest.php
@@ -41,6 +41,7 @@ final class GithubPackageReleaseAssetsTest extends TestCase
             $phpBinaryPath,
             Architecture::x86,
             ThreadSafetyMode::ThreadSafe,
+            1,
             WindowsCompiler::VC14,
         );
 
@@ -97,6 +98,7 @@ final class GithubPackageReleaseAssetsTest extends TestCase
             $phpBinaryPath,
             Architecture::x86,
             ThreadSafetyMode::ThreadSafe,
+            1,
             WindowsCompiler::VC14,
         );
 
@@ -148,6 +150,7 @@ final class GithubPackageReleaseAssetsTest extends TestCase
             PhpBinaryPath::fromCurrentProcess(),
             Architecture::x86,
             ThreadSafetyMode::ThreadSafe,
+            1,
             WindowsCompiler::VC14,
         );
 

--- a/test/unit/Downloading/UnixDownloadAndExtractTest.php
+++ b/test/unit/Downloading/UnixDownloadAndExtractTest.php
@@ -32,6 +32,7 @@ final class UnixDownloadAndExtractTest extends TestCase
             PhpBinaryPath::fromCurrentProcess(),
             Architecture::x86,
             ThreadSafetyMode::NonThreadSafe,
+            1,
             null,
         );
 

--- a/test/unit/Downloading/WindowsDownloadAndExtractTest.php
+++ b/test/unit/Downloading/WindowsDownloadAndExtractTest.php
@@ -37,6 +37,7 @@ final class WindowsDownloadAndExtractTest extends TestCase
             PhpBinaryPath::fromCurrentProcess(),
             Architecture::x86,
             ThreadSafetyMode::ThreadSafe,
+            1,
             WindowsCompiler::VC14,
         );
 

--- a/test/unit/Installing/InstallNotification/SendInstallNotificationUsingGuzzleTest.php
+++ b/test/unit/Installing/InstallNotification/SendInstallNotificationUsingGuzzleTest.php
@@ -53,6 +53,7 @@ final class SendInstallNotificationUsingGuzzleTest extends TestCase
             $phpBinaryPath,
             Architecture::x86,
             ThreadSafetyMode::ThreadSafe,
+            1,
             WindowsCompiler::VC14,
         );
     }

--- a/test/unit/Platform/TargetPlatformTest.php
+++ b/test/unit/Platform/TargetPlatformTest.php
@@ -50,7 +50,7 @@ Zend Extension Build => API420230831,TS,VS16
 PHP Extension Build => API20230831,TS,VS16
 TEXT);
 
-        $platform = TargetPlatform::fromPhpBinaryPath($phpBinaryPath);
+        $platform = TargetPlatform::fromPhpBinaryPath($phpBinaryPath, null);
 
         self::assertSame(OperatingSystem::Windows, $platform->operatingSystem);
         self::assertSame(WindowsCompiler::VS16, $platform->windowsCompiler);
@@ -91,7 +91,7 @@ Debug Build => no
 Thread Safety => disabled
 TEXT);
 
-        $platform = TargetPlatform::fromPhpBinaryPath($phpBinaryPath);
+        $platform = TargetPlatform::fromPhpBinaryPath($phpBinaryPath, null);
 
         self::assertSame(OperatingSystem::NonWindows, $platform->operatingSystem);
         self::assertSame(null, $platform->windowsCompiler);

--- a/test/unit/Platform/WindowsExtensionAssetNameTest.php
+++ b/test/unit/Platform/WindowsExtensionAssetNameTest.php
@@ -33,6 +33,7 @@ final class WindowsExtensionAssetNameTest extends TestCase
             PhpBinaryPath::fromCurrentProcess(),
             Architecture::x86_64,
             ThreadSafetyMode::ThreadSafe,
+            1,
             WindowsCompiler::VC14,
         );
 


### PR DESCRIPTION
Fixes #73 

PIE will try three approaches to determine the number of cores (`nproc --all`, `getconf __NPROCESSORS_ONLN`, `sysctl -n hw.ncpu`), or you can override with `-jN` or `--make-parallel-jobs=N` when running with PIE.

Doesn't cover Windows; or maybe some uncommon systems without those above commands. Suggestions welcome.