### PR TITLE
Fix building with multiple jobs for BSDmake

### DIFF
--- a/src/Building/UnixBuild.php
+++ b/src/Building/UnixBuild.php
@@ -100,8 +100,7 @@ final class UnixBuild implements Build
         if ($targetPlatform->makeParallelJobs === 1) {
             $output->writeln('Running make without parallelization - try providing -jN to PIE where N is the number of cores you have.');
         } else {
-            $makeCommand[] = '--jobs';
-            $makeCommand[] = (string) $targetPlatform->makeParallelJobs;
+            $makeCommand[] = sprintf('-j%d', $targetPlatform->makeParallelJobs);
         }
 
         return Process::run(


### PR DESCRIPTION
BSDmake does not accept the `--jobs` long-form flag and requires the use of `-j`.

The issue can be reproduced on a Ubuntu docker container by installing `bmake` and invoking that instead of `make`.

Fixes php/pie#80