### PR TITLE
Better authorization header handling in `AddAuthenticationHeader`

### DIFF
--- a/test/unit/Downloading/AddAuthenticationHeaderTest.php
+++ b/test/unit/Downloading/AddAuthenticationHeaderTest.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Php\PieUnitTest\Downloading;
 
 use Composer\Util\AuthHelper;
+use Generator;
 use GuzzleHttp\Psr7\Request;
 use Php\Pie\DependencyResolver\Package;
 use Php\Pie\Downloading\AddAuthenticationHeader;
 use Php\Pie\ExtensionName;
 use Php\Pie\ExtensionType;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -33,22 +35,46 @@ final class AddAuthenticationHeaderTest extends TestCase
 
         $requestWithAuthHeader = (new AddAuthenticationHeader())->withAuthHeaderFromComposer(
             $request,
-            new Package(
-                ExtensionType::PhpModule,
-                ExtensionName::normaliseFromString('foo'),
-                'foo/bar',
-                '1.2.3',
-                $downloadUrl,
-                [],
-                null,
-                '1.2.3.0',
-                true,
-                true,
-            ),
+            $this->createDummyPackage($downloadUrl),
             $authHelper,
         );
 
         self::assertSame('whatever ABC123', $requestWithAuthHeader->getHeaderLine('Authorization'));
+    }
+
+    #[DataProvider('provideInvalidAuthorizationHeaders')]
+    public function testEmptyValueInAuthorizationHeaderThrowsException(string $rawHeader): void
+    {
+        $downloadUrl = 'http://test-uri/' . uniqid('path', true);
+
+        $request = new Request('GET', $downloadUrl);
+
+        $authHelper = $this->createMock(AuthHelper::class);
+        $authHelper->expects(self::once())
+            ->method('addAuthenticationHeader')
+            ->with([], 'github.com', $downloadUrl)
+            ->willReturn([$rawHeader]);
+
+        $addAuthenticationHeader = new AddAuthenticationHeader();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Authorization header is malformed, it should contain a non-empty key and a non-empty value.');
+        $addAuthenticationHeader->withAuthHeaderFromComposer($request, $this->createDummyPackage($downloadUrl), $authHelper);
+    }
+
+    /**
+     * @return Generator<string[]>
+     *
+     * @psalm-suppress PossiblyUnusedMethod https://github.com/psalm/psalm-plugin-phpunit/issues/131
+     */
+    public static function provideInvalidAuthorizationHeaders(): Generator
+    {
+        yield ['Authorization:'];
+        yield [': Bearer'];
+        yield [' : Bearer'];
+        yield ['Authorization: '];
+        yield [':'];
+        yield ['Authorization MyToken'];
     }
 
     public function testExceptionIsThrownWhenPackageDoesNotHaveDownloadUrl(): void
@@ -60,21 +86,26 @@ final class AddAuthenticationHeaderTest extends TestCase
         $authHelper = $this->createMock(AuthHelper::class);
 
         $addAuthenticationHeader = new AddAuthenticationHeader();
-        $package                 = new Package(
+        $package                 = $this->createDummyPackage();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The package foo/bar does not have a download URL');
+        $addAuthenticationHeader->withAuthHeaderFromComposer($request, $package, $authHelper);
+    }
+
+    private function createDummyPackage(string|null $downloadUrl = null): Package
+    {
+        return new Package(
             ExtensionType::PhpModule,
             ExtensionName::normaliseFromString('foo'),
             'foo/bar',
             '1.2.3',
-            null,
+            $downloadUrl,
             [],
             null,
             '1.2.3.0',
             true,
             true,
         );
-
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The package foo/bar does not have a download URL');
-        $addAuthenticationHeader->withAuthHeaderFromComposer($request, $package, $authHelper);
     }
 }


### PR DESCRIPTION
By limiting the number of results that `explode()` returns, we're fine dealing with values containing a `:`. Also, it ease the check of the parts validity as the result is way more deterministic compared to calling to `explode()` without limit.