### PR TITLE
Add the `--with-phpize-path` option

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -74,6 +74,13 @@ to run PIE, but we want to download the extension for PHP 8.3:
 > C:\php-8.1.7\php.exe C:\pie.phar install --with-php-path=C:\php-8.3.6\php.exe example/example-pie-extension
 ```
 
+You may also need to use the corresponding `phpize` command for the target PHP
+version, which can be specified with the `--with-phpize-path` option:
+
+```shell
+pie install --with-phpize-path=/usr/bin/phpize7.2 my/extension
+```
+
 ### Version constraints and stability
 
 You may optionally specify a version constraint when using PIE to install an

--- a/src/Building/Build.php
+++ b/src/Building/Build.php
@@ -6,6 +6,7 @@ namespace Php\Pie\Building;
 
 use Php\Pie\BinaryFile;
 use Php\Pie\Downloading\DownloadedPackage;
+use Php\Pie\Platform\TargetPhp\PhpizePath;
 use Php\Pie\Platform\TargetPlatform;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -18,5 +19,6 @@ interface Build
         TargetPlatform $targetPlatform,
         array $configureOptions,
         OutputInterface $output,
+        PhpizePath|null $phpizePath,
     ): BinaryFile;
 }

--- a/src/Building/UnixBuild.php
+++ b/src/Building/UnixBuild.php
@@ -30,6 +30,7 @@ final class UnixBuild implements Build
         TargetPlatform $targetPlatform,
         array $configureOptions,
         OutputInterface $output,
+        PhpizePath|null $phpizePath,
     ): BinaryFile {
         $outputCallback = null;
         if ($output->isVerbose()) {
@@ -45,7 +46,7 @@ final class UnixBuild implements Build
         }
 
         $this->phpize(
-            PhpizePath::guessFrom($targetPlatform->phpBinaryPath),
+            $phpizePath ?? PhpizePath::guessFrom($targetPlatform->phpBinaryPath),
             $downloadedPackage,
             $output,
             $outputCallback,

--- a/src/Building/WindowsBuild.php
+++ b/src/Building/WindowsBuild.php
@@ -6,6 +6,7 @@ namespace Php\Pie\Building;
 
 use Php\Pie\BinaryFile;
 use Php\Pie\Downloading\DownloadedPackage;
+use Php\Pie\Platform\TargetPhp\PhpizePath;
 use Php\Pie\Platform\TargetPlatform;
 use Php\Pie\Platform\WindowsExtensionAssetName;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -21,6 +22,7 @@ final class WindowsBuild implements Build
         TargetPlatform $targetPlatform,
         array $configureOptions,
         OutputInterface $output,
+        PhpizePath|null $phpizePath,
     ): BinaryFile {
         $prebuiltDll = WindowsExtensionAssetName::determineDllName($targetPlatform, $downloadedPackage);
 

--- a/src/Command/BuildCommand.php
+++ b/src/Command/BuildCommand.php
@@ -53,6 +53,7 @@ final class BuildCommand extends Command
                 $requestedNameAndVersion,
                 PieOperation::Resolve,
                 [], // Configure options are not needed for resolve only
+                null,
             ),
         );
 
@@ -72,6 +73,7 @@ final class BuildCommand extends Command
                 $requestedNameAndVersion,
                 PieOperation::Build,
                 $configureOptionsValues,
+                CommandHelper::determinePhpizePathFromInputs($input),
             ),
         );
 

--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -11,6 +11,7 @@ use Php\Pie\DependencyResolver\Package;
 use Php\Pie\DependencyResolver\RequestedPackageAndVersion;
 use Php\Pie\Platform\OperatingSystem;
 use Php\Pie\Platform\TargetPhp\PhpBinaryPath;
+use Php\Pie\Platform\TargetPhp\PhpizePath;
 use Php\Pie\Platform\TargetPlatform;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -25,6 +26,7 @@ use function is_string;
 use function reset;
 use function sprintf;
 use function strtolower;
+use function trim;
 
 use const PHP_VERSION;
 
@@ -34,6 +36,7 @@ final class CommandHelper
     private const ARG_REQUESTED_PACKAGE_AND_VERSION = 'requested-package-and-version';
     private const OPTION_WITH_PHP_CONFIG            = 'with-php-config';
     private const OPTION_WITH_PHP_PATH              = 'with-php-path';
+    private const OPTION_WITH_PHPIZE_PATH           = 'with-phpize-path';
     private const OPTION_MAKE_PARALLEL_JOBS         = 'make-parallel-jobs';
 
     /** @psalm-suppress UnusedConstructor */
@@ -69,6 +72,12 @@ final class CommandHelper
             'j',
             InputOption::VALUE_REQUIRED,
             'Override many jobs to run in parallel when running compiling (this is passed to "make -jN" during build). PIE will try to detect this by default.',
+        );
+        $command->addOption(
+            self::OPTION_WITH_PHPIZE_PATH,
+            null,
+            InputOption::VALUE_REQUIRED,
+            'The path to the `phpize` binary to use as the target PHP platform, e.g. --' . self::OPTION_WITH_PHPIZE_PATH . '=/usr/bin/phpize7.4',
         );
 
         self::configurePhpConfigOptions($command);
@@ -134,6 +143,19 @@ final class CommandHelper
         ));
 
         return $targetPlatform;
+    }
+
+    public static function determinePhpizePathFromInputs(InputInterface $input): PhpizePath|null
+    {
+        if ($input->hasOption(self::OPTION_WITH_PHPIZE_PATH)) {
+            $phpizePathOption = (string) $input->getOption(self::OPTION_WITH_PHPIZE_PATH);
+            if (trim($phpizePathOption) !== '') {
+                /** @psalm-suppress ArgumentTypeCoercion */
+                return new PhpizePath($phpizePathOption);
+            }
+        }
+
+        return null;
     }
 
     public static function requestedNameAndVersionPair(InputInterface $input): RequestedPackageAndVersion

--- a/src/Command/DownloadCommand.php
+++ b/src/Command/DownloadCommand.php
@@ -55,6 +55,7 @@ final class DownloadCommand extends Command
                 $requestedNameAndVersion,
                 PieOperation::Download,
                 [], // Configure options are not needed for download only
+                null,
             ),
         );
 

--- a/src/Command/InfoCommand.php
+++ b/src/Command/InfoCommand.php
@@ -53,6 +53,7 @@ final class InfoCommand extends Command
                 $requestedNameAndVersion,
                 PieOperation::Resolve,
                 [], // Configure options are not needed for resolve only
+                null,
             ),
         );
 

--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -58,6 +58,7 @@ final class InstallCommand extends Command
                 $requestedNameAndVersion,
                 PieOperation::Resolve,
                 [], // Configure options are not needed for resolve only
+                null,
             ),
         );
 
@@ -77,6 +78,7 @@ final class InstallCommand extends Command
                 $requestedNameAndVersion,
                 PieOperation::Install,
                 $configureOptionsValues,
+                CommandHelper::determinePhpizePathFromInputs($input),
             ),
         );
 

--- a/src/ComposerIntegration/InstallAndBuildProcess.php
+++ b/src/ComposerIntegration/InstallAndBuildProcess.php
@@ -55,6 +55,7 @@ class InstallAndBuildProcess
                 $composerRequest->targetPlatform,
                 $composerRequest->configureOptions,
                 $output,
+                $composerRequest->phpizePath,
             );
 
             $this->installedJsonMetadata->addBuildMetadata(

--- a/src/ComposerIntegration/InstalledJsonMetadata.php
+++ b/src/ComposerIntegration/InstalledJsonMetadata.php
@@ -76,6 +76,13 @@ class InstalledJsonMetadata
         $this->addPieMetadata(
             $composer,
             $composerPackage,
+            MetadataKey::PhpizeBinary,
+            $composerRequest->phpizePath->phpizeBinaryPath ?? null,
+        );
+
+        $this->addPieMetadata(
+            $composer,
+            $composerPackage,
             MetadataKey::BuiltBinary,
             $builtBinary->filePath,
         );

--- a/src/ComposerIntegration/PieComposerRequest.php
+++ b/src/ComposerIntegration/PieComposerRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Php\Pie\ComposerIntegration;
 
 use Php\Pie\DependencyResolver\RequestedPackageAndVersion;
+use Php\Pie\Platform\TargetPhp\PhpizePath;
 use Php\Pie\Platform\TargetPlatform;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -22,6 +23,7 @@ final class PieComposerRequest
         public readonly RequestedPackageAndVersion $requestedPackage,
         public readonly PieOperation $operation,
         public readonly array $configureOptions,
+        public readonly PhpizePath|null $phpizePath,
     ) {
     }
 }

--- a/src/ComposerIntegration/PieInstalledJsonMetadataKeys.php
+++ b/src/ComposerIntegration/PieInstalledJsonMetadataKeys.php
@@ -16,4 +16,5 @@ enum PieInstalledJsonMetadataKeys: string
     case BuiltBinary                      = 'pie-built-binary';
     case BinaryChecksum                   = 'pie-installed-binary-checksum';
     case InstalledBinary                  = 'pie-installed-binary';
+    case PhpizeBinary                     = 'pie-phpize-binary';
 }

--- a/src/Platform/TargetPhp/PhpizePath.php
+++ b/src/Platform/TargetPhp/PhpizePath.php
@@ -66,7 +66,6 @@ final class PhpizePath
             }
         }
 
-        // @todo add a way to specify --phpize or similar
-        throw new RuntimeException('did not find a good phpize, oh');
+        throw new RuntimeException('Could not find a suitable `phpize` binary, you may provide one using the "--with-phpize-path" option.');
     }
 }

--- a/test/integration/Building/UnixBuildTest.php
+++ b/test/integration/Building/UnixBuildTest.php
@@ -53,6 +53,7 @@ final class UnixBuildTest extends TestCase
             TargetPlatform::fromPhpBinaryPath(PhpBinaryPath::fromCurrentProcess(), null),
             ['--enable-pie_test_ext'],
             $output,
+            null,
         );
 
         self::assertNotEmpty($builtBinary);

--- a/test/integration/DependencyResolver/ResolveDependencyWithComposerTest.php
+++ b/test/integration/DependencyResolver/ResolveDependencyWithComposerTest.php
@@ -89,6 +89,7 @@ final class ResolveDependencyWithComposerTest extends TestCase
                     $requestedPackageAndVersion,
                     PieOperation::Resolve,
                     [],
+                    null,
                 ),
             ),
             $targetPlatform,

--- a/test/integration/Installing/UnixInstallTest.php
+++ b/test/integration/Installing/UnixInstallTest.php
@@ -99,6 +99,7 @@ final class UnixInstallTest extends TestCase
             $targetPlatform,
             ['--enable-pie_test_ext'],
             $output,
+            null,
         );
 
         $installedSharedObject = (new UnixInstall())->__invoke(

--- a/test/unit/ComposerIntegration/InstallAndBuildProcessTest.php
+++ b/test/unit/ComposerIntegration/InstallAndBuildProcessTest.php
@@ -65,6 +65,7 @@ final class InstallAndBuildProcessTest extends TestCase
             new RequestedPackageAndVersion('foo/bar', '^1.0'),
             PieOperation::Download,
             ['--foo', '--bar="yes"'],
+            null,
         );
         $composerPackage = new CompletePackage('foo/bar', '1.2.3.0', '1.2.3');
         $installPath     = '/path/to/install';
@@ -104,6 +105,7 @@ final class InstallAndBuildProcessTest extends TestCase
             new RequestedPackageAndVersion('foo/bar', '^1.0'),
             PieOperation::Build,
             ['--foo', '--bar="yes"'],
+            null,
         );
         $composerPackage = new CompletePackage('foo/bar', '1.2.3.0', '1.2.3');
         $installPath     = '/path/to/install';
@@ -146,6 +148,7 @@ final class InstallAndBuildProcessTest extends TestCase
             new RequestedPackageAndVersion('foo/bar', '^1.0'),
             PieOperation::Install,
             ['--foo', '--bar="yes"'],
+            null,
         );
         $composerPackage = new CompletePackage('foo/bar', '1.2.3.0', '1.2.3');
         $installPath     = '/path/to/install';

--- a/test/unit/ComposerIntegration/InstalledJsonMetadataTest.php
+++ b/test/unit/ComposerIntegration/InstalledJsonMetadataTest.php
@@ -16,6 +16,7 @@ use Php\Pie\DependencyResolver\RequestedPackageAndVersion;
 use Php\Pie\Platform\Architecture;
 use Php\Pie\Platform\OperatingSystem;
 use Php\Pie\Platform\TargetPhp\PhpBinaryPath;
+use Php\Pie\Platform\TargetPhp\PhpizePath;
 use Php\Pie\Platform\TargetPlatform;
 use Php\Pie\Platform\ThreadSafetyMode;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -60,6 +61,7 @@ final class InstalledJsonMetadataTest extends TestCase
                 new RequestedPackageAndVersion('foo/bar', '^1.0'),
                 PieOperation::Build,
                 ['--foo', '--bar="yes"'],
+                null,
             ),
             clone $package,
         );
@@ -96,6 +98,7 @@ final class InstalledJsonMetadataTest extends TestCase
                 new RequestedPackageAndVersion('foo/bar', '^1.0'),
                 PieOperation::Build,
                 ['--foo', '--bar="yes"'],
+                new PhpizePath('/path/to/phpize'),
             ),
             clone $package,
             new BinaryFile('/path/to/built', 'sha256-checksum-value'),
@@ -104,6 +107,7 @@ final class InstalledJsonMetadataTest extends TestCase
         self::assertSame(
             [
                 'pie-configure-options' => '--foo --bar="yes"',
+                'pie-phpize-binary' => '/path/to/phpize',
                 'pie-built-binary' => '/path/to/built',
                 'pie-installed-binary-checksum' => 'sha256-checksum-value',
             ],

--- a/test/unit/ComposerIntegration/OverrideWindowsUrlInstallListenerTest.php
+++ b/test/unit/ComposerIntegration/OverrideWindowsUrlInstallListenerTest.php
@@ -77,6 +77,7 @@ final class OverrideWindowsUrlInstallListenerTest extends TestCase
                 new RequestedPackageAndVersion('foo/bar', '^1.1'),
                 PieOperation::Install,
                 [],
+                null,
             ),
         );
     }
@@ -120,6 +121,7 @@ final class OverrideWindowsUrlInstallListenerTest extends TestCase
                 new RequestedPackageAndVersion('foo/bar', '^1.1'),
                 PieOperation::Install,
                 [],
+                null,
             ),
         ))($installerEvent);
 
@@ -175,6 +177,7 @@ final class OverrideWindowsUrlInstallListenerTest extends TestCase
                 new RequestedPackageAndVersion('foo/bar', '^1.1'),
                 PieOperation::Install,
                 [],
+                null,
             ),
         ))($installerEvent);
 

--- a/test/unit/Platform/TargetPlatformTest.php
+++ b/test/unit/Platform/TargetPlatformTest.php
@@ -94,7 +94,7 @@ TEXT);
         $platform = TargetPlatform::fromPhpBinaryPath($phpBinaryPath, null);
 
         self::assertSame(OperatingSystem::NonWindows, $platform->operatingSystem);
-        self::assertSame(null, $platform->windowsCompiler);
+        self::assertNull($platform->windowsCompiler);
         self::assertSame(ThreadSafetyMode::NonThreadSafe, $platform->threadSafety);
         self::assertSame(Architecture::x86_64, $platform->architecture);
     }


### PR DESCRIPTION
Just like the `--with-php-config` and `--with-php-path` options, you can specify the path to `phpize` with this new option. If the option is not given, we fallback on the current `phpize` autodetection.