### PR TITLE
Replace x86_64 by x64 in Windows documentation

### DIFF
--- a/docs/extension-maintainers.md
+++ b/docs/extension-maintainers.md
@@ -166,7 +166,7 @@ Windows-compatible releases is:
 The name of the ZIP file, and the DLL contained within must be:
 
 * `php_{extension-name}-{tag}-{php-maj/min}-{ts|nts}-{compiler}-{arch}.zip`
-* Example: `php_xdebug-3.3.2-8.3-ts-vs16-x86_64.zip`
+* Example: `php_xdebug-3.3.2-8.3-ts-vs16-x64.zip`
 
 The descriptions of these items:
 
@@ -176,7 +176,7 @@ The descriptions of these items:
 * `compiler` - usually something like `vc6`, `vs16` - fetch from
   'PHP Extension Build' flags in `php -i`
 * `ts|nts` - Thread-safe or non-thread safe.
-* `arch` - for example `x86_64`.
+* `arch` - for example `x64`, `x86`, `arm64`.
    * Windows: `Architecture` from `php -i`
    * non-Windows: check `PHP_INT_SIZE` - 4 for 32-bit, 8 for 64-bit.
 


### PR DESCRIPTION
For Windows, the arch code is `x86` for Intel 32 bit, `x64` for Intel 64 bit, and `arm64` for ARM 64 bit.

This is the extract from some PHP versions on Windows:

![image](https://github.com/user-attachments/assets/b7c445e5-d018-4ab2-b192-62b8dbb9cc82)

![image](https://github.com/user-attachments/assets/84c9c92a-a2a0-4082-9418-c1b5c520b00f)

![image](https://github.com/user-attachments/assets/ac180dbd-542b-4371-9f09-156030aa5bbb)
