### PR TITLE
Prevent the `--with-phpize-path` option to be used on Windows

### DIFF
--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -113,6 +113,15 @@ final class CommandHelper
             throw new InvalidArgumentException('The --with-php-path=/path/to/php cannot be used on non-Windows, use --with-php-config=/path/to/php-config instead.');
         }
 
+        if (Platform::isWindows() && $input->hasOption(self::OPTION_WITH_PHPIZE_PATH)) {
+            /** @var mixed $withPhpizePath */
+            $withPhpizePath = $input->getOption(self::OPTION_WITH_PHPIZE_PATH);
+
+            if (is_string($withPhpizePath) && trim($withPhpizePath) !== '') {
+                throw new InvalidArgumentException('The --with-phpize-path=/path/to/phpize cannot be used on Windows.');
+            }
+        }
+
         if ($specifiedWithPhpConfig) {
             $phpBinaryPath = PhpBinaryPath::fromPhpConfigExecutable($withPhpConfig);
         }

--- a/test/unit/Command/CommandHelperTest.php
+++ b/test/unit/Command/CommandHelperTest.php
@@ -15,6 +15,7 @@ use Php\Pie\ExtensionName;
 use Php\Pie\ExtensionType;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresOperatingSystemFamily;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -157,6 +158,20 @@ final class CommandHelperTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The --with-php-path=/path/to/php cannot be used on non-Windows, use --with-php-config=/path/to/php-config instead.');
+        CommandHelper::determineTargetPlatformFromInputs($input, $output);
+    }
+
+    #[RequiresOperatingSystemFamily('Windows')]
+    public function testWindowsMachinesCannotUseWithPhpizePathOption(): void
+    {
+        $command = new Command();
+        $input   = new ArrayInput(['--with-phpize-path' => 'C:\path\to\phpize']);
+        $output  = new NullOutput();
+        CommandHelper::configureDownloadBuildInstallOptions($command);
+        CommandHelper::validateInput($input, $command);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The --with-phpize-path=/path/to/phpize cannot be used on Windows.');
         CommandHelper::determineTargetPlatformFromInputs($input, $output);
     }
 }


### PR DESCRIPTION
Followup of #96 