### PR TITLE
Use `#[RequiresOperatingSystemFamily]` where possible

### DIFF
--- a/test/integration/Command/DownloadCommandTest.php
+++ b/test/integration/Command/DownloadCommandTest.php
@@ -10,6 +10,8 @@ use Php\Pie\Container;
 use Php\Pie\DependencyResolver\UnableToResolveRequirement;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresOperatingSystemFamily;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -18,7 +20,6 @@ use function array_map;
 use function file_exists;
 use function is_executable;
 
-use const PHP_VERSION;
 use const PHP_VERSION_ID;
 
 #[CoversClass(DownloadCommand::class)]
@@ -96,13 +97,10 @@ class DownloadCommandTest extends TestCase
         );
     }
 
+    #[RequiresOperatingSystemFamily('Windows')]
     #[DataProvider('validVersionsList')]
     public function testDownloadingWithPhpConfig(string $requestedVersion, string $expectedVersion): void
     {
-        if (! Platform::isWindows()) {
-            self::markTestSkipped('This test can only run on Windows');
-        }
-
         // @todo This test makes an assumption you're using `ppa:ondrej/php` to have multiple PHP versions. This allows
         //       us to test scenarios where you run with PHP 8.1 but want to install to a PHP 8.3 instance, for example.
         //       However, this test isn't very portable, and won't run in CI, so we could do with improving this later.
@@ -124,13 +122,10 @@ class DownloadCommandTest extends TestCase
         self::assertStringContainsString('Extracted ' . $expectedVersion . ' source to', $outputString);
     }
 
+    #[RequiresOperatingSystemFamily('Windows')]
     #[DataProvider('validVersionsList')]
     public function testDownloadingWithPhpPath(string $requestedVersion, string $expectedVersion): void
     {
-        if (! Platform::isWindows()) {
-            self::markTestSkipped('This test can only run on Windows');
-        }
-
         $phpBinaryPath = 'C:\php-8.3.6\php.exe';
 
         if (! file_exists($phpBinaryPath) || ! is_executable($phpBinaryPath)) {
@@ -149,12 +144,9 @@ class DownloadCommandTest extends TestCase
         self::assertStringContainsString('Extracted ' . $expectedVersion . ' source to', $outputString);
     }
 
+    #[RequiresPhp('<8.2')]
     public function testDownloadCommandFailsWhenUsingIncompatiblePhpVersion(): void
     {
-        if (PHP_VERSION_ID >= 80200) {
-            self::markTestSkipped('This test can only run on older than PHP 8.2 - you are running ' . PHP_VERSION);
-        }
-
         $this->expectException(UnableToResolveRequirement::class);
         // 1.0.0 is only compatible with PHP 8.3.0
         $this->commandTester->execute(['requested-package-and-version' => self::TEST_PACKAGE . ':1.0.0']);

--- a/test/integration/Command/InstallCommandTest.php
+++ b/test/integration/Command/InstallCommandTest.php
@@ -9,6 +9,7 @@ use Php\Pie\Command\InstallCommand;
 use Php\Pie\Container;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresOperatingSystemFamily;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -108,12 +109,9 @@ class InstallCommandTest extends TestCase
         (new Process($rmCommand))->mustRun();
     }
 
+    #[RequiresOperatingSystemFamily('Windows')]
     public function testInstallCommandWillInstallCompatibleExtensionWindows(): void
     {
-        if (! Platform::isWindows()) {
-            self::markTestSkipped('This test can only run on Windows systems');
-        }
-
         $this->commandTester->execute(['requested-package-and-version' => self::TEST_PACKAGE]);
 
         $this->commandTester->assertCommandIsSuccessful();

--- a/test/integration/Installing/WindowsInstallTest.php
+++ b/test/integration/Installing/WindowsInstallTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Php\PieIntegrationTest\Installing;
 
 use Composer\Package\CompletePackage;
-use Composer\Util\Platform;
 use Php\Pie\DependencyResolver\Package;
 use Php\Pie\Downloading\DownloadedPackage;
 use Php\Pie\ExtensionName;
@@ -18,6 +17,7 @@ use Php\Pie\Platform\TargetPlatform;
 use Php\Pie\Platform\ThreadSafetyMode;
 use Php\Pie\Platform\WindowsCompiler;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RequiresOperatingSystemFamily;
 use PHPUnit\Framework\TestCase;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -39,12 +39,9 @@ final class WindowsInstallTest extends TestCase
 {
     private const TEST_EXTENSION_PATH = __DIR__ . '/../../assets/pie_test_ext_win';
 
+    #[RequiresOperatingSystemFamily('Windows')]
     public function testWindowsInstallCanInstallExtension(): void
     {
-        if (! Platform::isWindows()) {
-            self::markTestSkipped('Test can only be run on Windows');
-        }
-
         $downloadedPackage = DownloadedPackage::fromPackageAndExtractedPath(
             new Package(
                 $this->createMock(CompletePackage::class),

--- a/test/unit/Command/CommandHelperTest.php
+++ b/test/unit/Command/CommandHelperTest.php
@@ -15,6 +15,7 @@ use Php\Pie\ExtensionName;
 use Php\Pie\ExtensionType;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresOperatingSystemFamily;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -126,12 +127,9 @@ final class CommandHelperTest extends TestCase
         );
     }
 
+    #[RequiresOperatingSystemFamily('Windows')]
     public function testWindowsMachinesCannotUseWithPhpConfigOption(): void
     {
-        if (! Platform::isWindows()) {
-            self::markTestSkipped('This test can only run on Windows');
-        }
-
         $command = new Command();
         $input   = new ArrayInput(['--with-php-config' => 'C:\path\to\php-config']);
         $output  = new NullOutput();


### PR DESCRIPTION
It is easier to find all tests where Windows is required, as `self::markTestSkipped()` messages are not 100% consistent across all calls. Also it should be better for PHPUnit so it doesn't have to start executing the test to skip it.