### PR TITLE
Add Homebrew TAP support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,3 +50,21 @@ jobs:
           files: |
             pie.phar
             pie.phar.asc
+      - name: Get release tag
+        run: |
+          RELEASE_TAG=${GITHUB_REF/refs\/tags\//}
+          echo "RELEASE_TAG=$RELEASE_TAG" >> $GITHUB_ENV
+      - name: Update Homebrew formula
+        uses: mislav/bump-homebrew-formula-action@v3
+        with:
+          formula-name: php-pie
+          formula-path: homebrew/Formula/php-pie.rb
+          homebrew-tap: php/pie
+          download-url: https://github.com/php/pie/releases/download/${{ env.RELEASE_TAG }}/pie.phar
+          commit-message: |
+            Update Homebrew TAP formula: {{formulaName}} to version: {{version}}
+
+            Commit executed by automatic flow after every release
+        env:
+          # the personal access token should have "repo" & "workflow" scopes
+          COMMITTER_TOKEN: ${{ secrets.ACCESS_TOKEN }}

--- a/homebrew/Formula/php-pie.rb
+++ b/homebrew/Formula/php-pie.rb
@@ -1,0 +1,17 @@
+class PhpPie < Formula
+  desc "PIE - the PHP Installer for Extensions"
+  homepage "https://github.com/php/pie"
+  url "https://github.com/php/pie/releases/download/0.2.0/pie.phar"
+  sha256 "a88f2ad1939b69fe1b44919b22e68743b4de2f33ea560880010e8565eb21ab12"
+  license "MIT"
+
+  depends_on "php"
+
+  def install
+    bin.install "pie.phar" => "pie"
+  end
+
+  test do
+    shell_output("#{bin}/pie --version").include?(version)
+  end
+end


### PR DESCRIPTION
This requires adding a new secret to actions `ACCESS_TOKEN` with "repo" & "workflow" scopes.