### PR TITLE
Make all PHPUnit data providers static

### DIFF
--- a/test/unit/ComposerIntegration/ComposerRunFailedTest.php
+++ b/test/unit/ComposerIntegration/ComposerRunFailedTest.php
@@ -17,7 +17,7 @@ final class ComposerRunFailedTest extends TestCase
      *
      * @psalm-suppress PossiblyUnusedMethod https://github.com/psalm/psalm-plugin-phpunit/issues/131
      */
-    public function errorCodesProvider(): array
+    public static function errorCodesProvider(): array
     {
         return [
             'exit-0' => [0, 'PIE Composer run failed with error code 0', 1], // probably not real scenario

--- a/test/unit/ComposerIntegration/QuieterConsoleIOTest.php
+++ b/test/unit/ComposerIntegration/QuieterConsoleIOTest.php
@@ -75,7 +75,7 @@ final class QuieterConsoleIOTest extends TestCase
      *
      * @psalm-suppress PossiblyUnusedMethod https://github.com/psalm/psalm-plugin-phpunit/issues/131
      */
-    public function verbosyExpectationsProvider(): array
+    public static function verbosyExpectationsProvider(): array
     {
         return [
             'q' => [OutputInterface::VERBOSITY_QUIET, []],

--- a/test/unit/DependencyResolver/PackageTest.php
+++ b/test/unit/DependencyResolver/PackageTest.php
@@ -47,7 +47,7 @@ final class PackageTest extends TestCase
      *
      * @psalm-suppress PossiblyUnusedMethod https://github.com/psalm/psalm-plugin-phpunit/issues/131
      */
-    public function githubOrgAndRepoFromPackage(): array
+    public static function githubOrgAndRepoFromPackage(): array
     {
         return [
             'noDownloadUrl' => ['foo/bar', null, 'foo/bar'],


### PR DESCRIPTION
Non-static data providers is deprecated since PHPUnit 10.