### PR TITLE
Add the `--dry-run` option

### DIFF
--- a/src/BinaryFile.php
+++ b/src/BinaryFile.php
@@ -15,6 +15,8 @@ final class BinaryFile
 {
     private const HASH_TYPE_SHA256 = 'sha256';
 
+    private const DRY_RUN_FAKE_HASH = 'dry_run_fake_hash';
+
     /**
      * @param non-empty-string $filePath
      * @param non-empty-string $checksum
@@ -31,6 +33,15 @@ final class BinaryFile
         return new self(
             $filePath,
             hash_file(self::HASH_TYPE_SHA256, $filePath),
+        );
+    }
+
+    /** @param non-empty-string $filePath */
+    public static function nonExistentForDryRun(string $filePath): self
+    {
+        return new self(
+            'dry-run::' . $filePath,
+            self::DRY_RUN_FAKE_HASH,
         );
     }
 }

--- a/src/Building/Build.php
+++ b/src/Building/Build.php
@@ -20,5 +20,6 @@ interface Build
         array $configureOptions,
         OutputInterface $output,
         PhpizePath|null $phpizePath,
+        bool $dryRun,
     ): BinaryFile;
 }

--- a/src/Building/WindowsBuild.php
+++ b/src/Building/WindowsBuild.php
@@ -23,6 +23,7 @@ final class WindowsBuild implements Build
         array $configureOptions,
         OutputInterface $output,
         PhpizePath|null $phpizePath,
+        bool $dryRun,
     ): BinaryFile {
         $prebuiltDll = WindowsExtensionAssetName::determineDllName($targetPlatform, $downloadedPackage);
 

--- a/src/Command/BuildCommand.php
+++ b/src/Command/BuildCommand.php
@@ -37,6 +37,7 @@ final class BuildCommand extends Command
         parent::configure();
 
         CommandHelper::configureDownloadBuildInstallOptions($this);
+        CommandHelper::configureDryRunOption($this);
     }
 
     public function execute(InputInterface $input, OutputInterface $output): int
@@ -54,6 +55,7 @@ final class BuildCommand extends Command
                 PieOperation::Resolve,
                 [], // Configure options are not needed for resolve only
                 null,
+                CommandHelper::determineDryRunFromInputs($input),
             ),
         );
 
@@ -74,6 +76,7 @@ final class BuildCommand extends Command
                 PieOperation::Build,
                 $configureOptionsValues,
                 CommandHelper::determinePhpizePathFromInputs($input),
+                false,
             ),
         );
 

--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -38,6 +38,7 @@ final class CommandHelper
     private const OPTION_WITH_PHP_PATH              = 'with-php-path';
     private const OPTION_WITH_PHPIZE_PATH           = 'with-phpize-path';
     private const OPTION_MAKE_PARALLEL_JOBS         = 'make-parallel-jobs';
+    private const OPTION_DRY_RUN                    = 'dry-run';
 
     /** @psalm-suppress UnusedConstructor */
     private function __construct()
@@ -87,6 +88,16 @@ final class CommandHelper
          * Note, this means you probably need to call {@see self::validateInput()} to validate the input manually...
          */
         $command->ignoreValidationErrors();
+    }
+
+    public static function configureDryRunOption(Command $command): void
+    {
+        $command->addOption(
+            self::OPTION_DRY_RUN,
+            null,
+            InputOption::VALUE_NONE,
+            'Do not actually build or install the extension, just show the steps that would be run.',
+        );
     }
 
     public static function validateInput(InputInterface $input, Command $command): void
@@ -152,6 +163,11 @@ final class CommandHelper
         ));
 
         return $targetPlatform;
+    }
+
+    public static function determineDryRunFromInputs(InputInterface $input): bool
+    {
+        return $input->hasOption(self::OPTION_DRY_RUN) && $input->getOption(self::OPTION_DRY_RUN);
     }
 
     public static function determinePhpizePathFromInputs(InputInterface $input): PhpizePath|null

--- a/src/Command/DownloadCommand.php
+++ b/src/Command/DownloadCommand.php
@@ -56,6 +56,7 @@ final class DownloadCommand extends Command
                 PieOperation::Download,
                 [], // Configure options are not needed for download only
                 null,
+                CommandHelper::determineDryRunFromInputs($input),
             ),
         );
 

--- a/src/Command/InfoCommand.php
+++ b/src/Command/InfoCommand.php
@@ -54,6 +54,7 @@ final class InfoCommand extends Command
                 PieOperation::Resolve,
                 [], // Configure options are not needed for resolve only
                 null,
+                CommandHelper::determineDryRunFromInputs($input),
             ),
         );
 

--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -38,6 +38,7 @@ final class InstallCommand extends Command
         parent::configure();
 
         CommandHelper::configureDownloadBuildInstallOptions($this);
+        CommandHelper::configureDryRunOption($this);
     }
 
     public function execute(InputInterface $input, OutputInterface $output): int
@@ -59,6 +60,7 @@ final class InstallCommand extends Command
                 PieOperation::Resolve,
                 [], // Configure options are not needed for resolve only
                 null,
+                CommandHelper::determineDryRunFromInputs($input),
             ),
         );
 
@@ -79,6 +81,7 @@ final class InstallCommand extends Command
                 PieOperation::Install,
                 $configureOptionsValues,
                 CommandHelper::determinePhpizePathFromInputs($input),
+                false,
             ),
         );
 

--- a/src/ComposerIntegration/InstallAndBuildProcess.php
+++ b/src/ComposerIntegration/InstallAndBuildProcess.php
@@ -56,6 +56,7 @@ class InstallAndBuildProcess
                 $composerRequest->configureOptions,
                 $output,
                 $composerRequest->phpizePath,
+                $composerRequest->dryRun,
             );
 
             $this->installedJsonMetadata->addBuildMetadata(
@@ -77,6 +78,7 @@ class InstallAndBuildProcess
                 $downloadedPackage,
                 $composerRequest->targetPlatform,
                 $output,
+                $composerRequest->dryRun,
             ),
         );
     }

--- a/src/ComposerIntegration/PieComposerRequest.php
+++ b/src/ComposerIntegration/PieComposerRequest.php
@@ -24,6 +24,7 @@ final class PieComposerRequest
         public readonly PieOperation $operation,
         public readonly array $configureOptions,
         public readonly PhpizePath|null $phpizePath,
+        public readonly bool $dryRun,
     ) {
     }
 }

--- a/src/Installing/Install.php
+++ b/src/Installing/Install.php
@@ -20,5 +20,6 @@ interface Install
         DownloadedPackage $downloadedPackage,
         TargetPlatform $targetPlatform,
         OutputInterface $output,
+        bool $dryRun,
     ): BinaryFile;
 }

--- a/test/integration/Building/UnixBuildTest.php
+++ b/test/integration/Building/UnixBuildTest.php
@@ -59,6 +59,7 @@ final class UnixBuildTest extends TestCase
             ['--enable-pie_test_ext'],
             $output,
             null,
+            false,
         );
 
         self::assertNotEmpty($builtBinary);
@@ -115,6 +116,7 @@ final class UnixBuildTest extends TestCase
                 ['--enable-pie_test_ext'],
                 $output,
                 null,
+                false,
             );
         } finally {
             (new Process(['make', 'clean'], $downloadedPackage->extractedSourcePath))->mustRun();
@@ -153,6 +155,7 @@ final class UnixBuildTest extends TestCase
             ['--enable-pie_test_ext'],
             $output,
             null,
+            false,
         );
 
         self::assertNotEmpty($builtBinary);
@@ -210,6 +213,7 @@ final class UnixBuildTest extends TestCase
             ['--enable-pie_test_ext'],
             $output,
             null,
+            false,
         );
 
         $outputString = $output->fetch();
@@ -252,6 +256,7 @@ final class UnixBuildTest extends TestCase
             ['--enable-pie_test_ext'],
             $output,
             null,
+            false,
         );
 
         $outputString = $output->fetch();

--- a/test/integration/DependencyResolver/ResolveDependencyWithComposerTest.php
+++ b/test/integration/DependencyResolver/ResolveDependencyWithComposerTest.php
@@ -90,6 +90,7 @@ final class ResolveDependencyWithComposerTest extends TestCase
                     PieOperation::Resolve,
                     [],
                     null,
+                    false,
                 ),
             ),
             $targetPlatform,

--- a/test/unit/ComposerIntegration/InstallAndBuildProcessTest.php
+++ b/test/unit/ComposerIntegration/InstallAndBuildProcessTest.php
@@ -66,6 +66,7 @@ final class InstallAndBuildProcessTest extends TestCase
             PieOperation::Download,
             ['--foo', '--bar="yes"'],
             null,
+            false,
         );
         $composerPackage = new CompletePackage('foo/bar', '1.2.3.0', '1.2.3');
         $installPath     = '/path/to/install';
@@ -106,6 +107,7 @@ final class InstallAndBuildProcessTest extends TestCase
             PieOperation::Build,
             ['--foo', '--bar="yes"'],
             null,
+            false,
         );
         $composerPackage = new CompletePackage('foo/bar', '1.2.3.0', '1.2.3');
         $installPath     = '/path/to/install';
@@ -149,6 +151,7 @@ final class InstallAndBuildProcessTest extends TestCase
             PieOperation::Install,
             ['--foo', '--bar="yes"'],
             null,
+            false,
         );
         $composerPackage = new CompletePackage('foo/bar', '1.2.3.0', '1.2.3');
         $installPath     = '/path/to/install';

--- a/test/unit/ComposerIntegration/InstalledJsonMetadataTest.php
+++ b/test/unit/ComposerIntegration/InstalledJsonMetadataTest.php
@@ -62,6 +62,7 @@ final class InstalledJsonMetadataTest extends TestCase
                 PieOperation::Build,
                 ['--foo', '--bar="yes"'],
                 null,
+                false,
             ),
             clone $package,
         );
@@ -99,6 +100,7 @@ final class InstalledJsonMetadataTest extends TestCase
                 PieOperation::Build,
                 ['--foo', '--bar="yes"'],
                 new PhpizePath('/path/to/phpize'),
+                false,
             ),
             clone $package,
             new BinaryFile('/path/to/built', 'sha256-checksum-value'),

--- a/test/unit/ComposerIntegration/OverrideWindowsUrlInstallListenerTest.php
+++ b/test/unit/ComposerIntegration/OverrideWindowsUrlInstallListenerTest.php
@@ -78,6 +78,7 @@ final class OverrideWindowsUrlInstallListenerTest extends TestCase
                 PieOperation::Install,
                 [],
                 null,
+                false,
             ),
         );
     }
@@ -122,6 +123,7 @@ final class OverrideWindowsUrlInstallListenerTest extends TestCase
                 PieOperation::Install,
                 [],
                 null,
+                false,
             ),
         ))($installerEvent);
 
@@ -178,6 +180,7 @@ final class OverrideWindowsUrlInstallListenerTest extends TestCase
                 PieOperation::Install,
                 [],
                 null,
+                false,
             ),
         ))($installerEvent);
 


### PR DESCRIPTION
Fix #18

Allows using the `--dry-run` option with both `build` and `install` command. This wasn't added the `download` command, as I'm not really sure it makes sense to have it.