### PR TITLE
Add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: /
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
The release.yml workflow currently emits a warning:

> The following actions use a deprecated Node.js version and will be forced to
> run on node20: softprops/action-gh-release@v1.

A newer version for that action is available. Dependabot should make it much easier to keep the actions up to date.