### PR TITLE
Run `composer bump`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
     "config": {
         "sort-packages": true,
         "preferred-install": "dist",
+        "bump-after-update": true,
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
         }

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "ext-zip": "*",
         "composer/composer": "dev-main",
         "fidry/cpu-core-counter": "^1.2",
-        "illuminate/container": "^10.48.23",
+        "illuminate/container": "^10.48.24",
         "symfony/console": "^6.4.15",
         "symfony/process": "^6.4.15",
         "webmozart/assert": "^1.11"

--- a/composer.json
+++ b/composer.json
@@ -31,18 +31,18 @@
         "ext-zip": "*",
         "composer/composer": "dev-main",
         "fidry/cpu-core-counter": "^1.2",
-        "illuminate/container": "^10.47",
-        "symfony/console": "^6.4",
-        "symfony/process": "^6.4",
+        "illuminate/container": "^10.48.23",
+        "symfony/console": "^6.4.15",
+        "symfony/process": "^6.4.15",
         "webmozart/assert": "^1.11"
     },
     "require-dev": {
-        "behat/behat": "^3.14",
+        "behat/behat": "^3.16",
         "doctrine/coding-standard": "^12.0",
         "php-standard-library/psalm-plugin": "^2.3",
-        "phpunit/phpunit": "^10.5",
+        "phpunit/phpunit": "^10.5.38",
         "psalm/plugin-phpunit": "^0.18.4",
-        "vimeo/psalm": "^5.22"
+        "vimeo/psalm": "^5.26.1"
     },
     "replace": {
         "symfony/polyfill-php81": "*",

--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,9 @@
         "bump-after-update": true,
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
+        },
+        "platform": {
+            "php": "8.1.0"
         }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b4784c9fd1c30ffc86bc4c24b3789654",
+    "content-hash": "da6eb5481a3dbb3ae210ba4cc52c0ab9",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -5949,6 +5949,6 @@
         "php": "8.1.*||8.2.*||8.3.*||8.4.*",
         "ext-zip": "*"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b04044ce9f53093d450e17204ccb1ef0",
+    "content-hash": "423e16235d3c132383c5527eba90ba36",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -5950,5 +5950,8 @@
         "ext-zip": "*"
     },
     "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.1.0"
+    },
     "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "da6eb5481a3dbb3ae210ba4cc52c0ab9",
+    "content-hash": "b04044ce9f53093d450e17204ccb1ef0",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -708,7 +708,7 @@
         },
         {
             "name": "illuminate/container",
-            "version": "v10.48.23",
+            "version": "v10.48.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",
@@ -759,7 +759,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v10.48.23",
+            "version": "v10.48.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -5949,6 +5949,6 @@
         "php": "8.1.*||8.2.*||8.3.*||8.4.*",
         "ext-zip": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
Given that PIE is a project rather than a library and is distributed as a Phar archive, we do not need to keep broad compatibility with older library versions. Run `composer bump` to prevent accidental downgrades of libraries, by increasing the versions in `composer.json` to match the currently locked versions in `composer.lock`.