### PR TITLE
feat: CI job for building Docker binary-only images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Restore built PHAR
+      - name: Fetch built PHAR from artifacts
         uses: actions/download-artifact@v4
         with:
           name: pie-${{ github.sha }}.phar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,7 @@ on:
       - published
 
 permissions:
-  attestations: write
   contents: read
-  id-token: write
-  packages: write
 
 jobs:
   build-phar:
@@ -47,6 +44,14 @@ jobs:
     name: Docker binary-only image
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
+
+    permissions:
+      # attestations:write is required to publish provenance attestations for the built Docker image
+      attestations: write
+      # id-token:write is required for logging in to the Docker registry
+      id-token: write
+      # packages:write is required to publish Docker images to GitHub's registry
+      packages: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,13 +86,12 @@ jobs:
         with:
           flavor: |
             latest=false
-            suffix=-bin
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=raw,value=latest
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=raw,value=bin
+            type=semver,pattern={{version}}-bin
+            type=semver,pattern={{major}}.{{minor}}-bin
+            type=semver,pattern={{major}}-bin
 
       - name: Build and push Docker image
         id: build-and-push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   build-phar:
@@ -38,3 +39,56 @@ jobs:
         if: ${{startsWith(github.ref, 'refs/tags/') }}
         with:
           files: pie.phar
+
+  docker-binary-only-image:
+    needs: build-phar
+    name: Docker binary-only image
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Restore built PHAR
+        uses: actions/download-artifact@v4
+        with:
+          name: pie-${{ github.sha }}.phar
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          flavor: |
+            latest=false
+            suffix=-bin
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          file: Dockerfile
+          target: standalone-binary
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,11 @@ jobs:
         with:
           name: pie-${{ github.sha }}.phar
 
+      - name: Verify the PHAR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh attestation verify pie.phar --repo ${{ github.repository }}
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,11 +46,11 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
 
     permissions:
-      # attestations:write is required to publish provenance attestations for the built Docker image
+      # attestations:write is required for build provenance attestation.
       attestations: write
-      # id-token:write is required for logging in to the Docker registry
+      # id-token:write is required for build provenance attestation.
       id-token: write
-      # packages:write is required to publish Docker images to GitHub's registry
+      # packages:write is required to publish Docker images to GitHub's registry.
       packages: write
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,11 +87,12 @@ jobs:
           flavor: |
             latest=false
           images: ghcr.io/${{ github.repository }}
+          # @TODO v1.0 Consider introducing more granular tags (major and major.minor)
+          # @see https://github.com/php/pie/pull/122#pullrequestreview-2477496308
+          # @see https://github.com/php/pie/pull/122#discussion_r1867331273
           tags: |
             type=raw,value=bin
             type=semver,pattern={{version}}-bin
-            type=semver,pattern={{major}}.{{minor}}-bin
-            type=semver,pattern={{major}}-bin
 
       - name: Build and push Docker image
         id: build-and-push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,9 @@ on:
       - published
 
 permissions:
+  attestations: write
   contents: read
+  id-token: write
   packages: write
 
 jobs:
@@ -88,6 +90,7 @@ jobs:
             type=semver,pattern={{major}}
 
       - name: Build and push Docker image
+        id: build-and-push
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -97,3 +100,10 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.build-and-push.outputs.digest }}
+          push-to-registry: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM scratch AS standalone-binary
+
+# @TODO change to --chmod=+x when https://github.com/moby/buildkit/pull/5380 is released
+COPY --chmod=0755 pie.phar /pie

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -35,7 +35,7 @@ PIE is published as binary-only Docker image, so you can install it easily durin
 COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
 ```
 
-Instead of `bin` tag (which represents latest binary-only image) you can also use explicit versions like `x.y.z-bin`, `x.y-bin` or `x-bin`, depending on stability level you want to achieve.
+Instead of `bin` tag (which represents latest binary-only image) you can also use explicit version (in `x.y.z-bin` format). Use [GitHub registry](https://ghcr.io/php/pie) to find available tags.
 
 > [!IMPORTANT]  
 > Binary-only images don't include PHP runtime so you can't use them for _running_ PIE. This is just an alternative way of distributing PHAR file, you still need to satisfy PIE's runtime requirements on your own.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -27,6 +27,19 @@ system:
 sudo curl -L --output /usr/local/bin/pie https://github.com/php/pie/releases/latest/download/pie.phar && sudo chmod +x /usr/local/bin/pie
 ```
 
+### Docker installation
+
+PIE is published as binary-only Docker image, so you can install it easily during your Docker build:
+
+```Dockerfile
+COPY --from=ghcr.io/php/pie:latest-bin /pie /usr/bin/pie
+```
+
+Instead of `latest` you can also use explicit versions like `x.y.z-bin`, `x.y-bin` or `x-bin`, depending on stability level you want to achieve.
+
+> [!IMPORTANT]  
+> Binary-only images don't include PHP runtime so you can't use them for _running_ PIE. This is just an alternative way of distributing PHAR file, you still need to satisfy PIE's runtime requirements on your own.
+
 ## Prerequisites for PIE
 
 Running PIE requires PHP 8.1 or newer. However, you may still use PIE to install

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -32,10 +32,10 @@ sudo curl -L --output /usr/local/bin/pie https://github.com/php/pie/releases/lat
 PIE is published as binary-only Docker image, so you can install it easily during your Docker build:
 
 ```Dockerfile
-COPY --from=ghcr.io/php/pie:latest-bin /pie /usr/bin/pie
+COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
 ```
 
-Instead of `latest` you can also use explicit versions like `x.y.z-bin`, `x.y-bin` or `x-bin`, depending on stability level you want to achieve.
+Instead of `bin` tag (which represents latest binary-only image) you can also use explicit versions like `x.y.z-bin`, `x.y-bin` or `x-bin`, depending on stability level you want to achieve.
 
 > [!IMPORTANT]  
 > Binary-only images don't include PHP runtime so you can't use them for _running_ PIE. This is just an alternative way of distributing PHAR file, you still need to satisfy PIE's runtime requirements on your own.


### PR DESCRIPTION
Similar to composer/docker#250 ([more info](https://blog.codito.dev/2022/11/composer-binary-only-docker-images/)), this PR introduces a CI process for releasing binary-only images for Pie 🥳!

You can see the result [here](https://github.com/wirone/php-pie/pkgs/container/php-pie), there is an image in my fork's Package Registry, built [here](https://github.com/Wirone/php-pie/actions/runs/12083428508/job/33696550468).

Here's how the image looks like (`dive ghcr.io/wirone/php-pie:latest-bin`):
<img width="1144" alt="image" src="https://github.com/user-attachments/assets/76ad164b-67d4-4ef4-acdc-e3a616bdd352">

~~PS: I decided to not verify GPG signature during build because we can trust our own workflow (we copy PHAR file built in previous stage), but also I had some problems with verification (GPG imported correctly, but verification failed). Users may verify the file on their own, if they want, using attached `pie.asc`.~~ Signing was dropped.

Fixes #137 