### PR TITLE
Fix build phar job on forks that have no tags

### DIFF
--- a/.github/workflows/release-unsigned-phar.yml
+++ b/.github/workflows/release-unsigned-phar.yml
@@ -23,6 +23,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      # Ensure some kind of previous tag exists, otherwise box fails
+      - run: git describe --tags HEAD || git tag 0.0.0
       - uses: ramsey/composer-install@v3
       - name: Build PHAR
         run: box compile


### PR DESCRIPTION
Push actions on forks without tags will fail without this, this should help contributors once merged