### PR TITLE
Enable Dependabot for composer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: /
     schedule:
       interval: "monthly"
+  - package-ecosystem: "composer"
+    directory: /
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Since php/pie#121 composer is configured to bump the minimally supported version of dependencies when manually performing updates to composer dependencies. Composer is also configured such that it will not offer any dependencies that are incompatible with PHP 8.1 as the lowest supported PHP version.

This allows to reliably enable Dependabot also for composer dependencies, as it will do the right thing and of course CI will double check that. This absolves the maintainer from manually needing to check for updates every so often, because they will be delivered by a PR once a month, making it easy to keep the dependencies up to date and secure.

Correct behavior was verified in a fork. As a result of merging this PR, Dependabot will offer an update of `psalm/plugin-phpunit` to 0.19.0, which will not automatically be performed by `composer update`, given it's considered a major version, showcasing the benefit of the Dependabot integration.