### PR TITLE
Configure fine-grained GitHub Action permissions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
     runs-on: ${{ matrix.operating-system }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,11 +8,8 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -52,6 +49,12 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: read
+      # pages:write is required to deploy to GitHub pages.
+      pages: write
+      # id-token:write is required to deploy to GitHub pages.
+      id-token: write
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/release-unsigned-phar.yml
+++ b/.github/workflows/release-unsigned-phar.yml
@@ -3,8 +3,10 @@ name: "Release unsigned PHAR"
 on:
   workflow_call:
 
-jobs:
+permissions:
+  contents: read
 
+jobs:
   build-phar:
     runs-on: ${{ matrix.operating-system }}
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     types:
       - published
 
+permissions:
+  contents: read
+
 jobs:
   release-phar:
     runs-on: ${{ matrix.operating-system }}
@@ -14,6 +17,9 @@ jobs:
           - ubuntu-latest
         php-versions:
           - '8.1'
+    permissions:
+      # contents:write is required to upload the binaries to the release.
+      contents: write
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
I was not able to test the workflows requiring the additional permissions, because I obviously do not have a signing key set up. I'm reasonably confident that these changes are correct though.

@asgrim I'm not sure if you are able to make the necessary changes to the repository configuration. You might need to request assistance by a organization owner.

-----------------

This change configures GitHub Actions to only allow reading the repository contents within the top-level workflow-wide permissions section. Extended permissions are then granted to individual jobs to make permissions “secure by default” even when additional jobs are added to an existing workflow.

As a follow-up to this PR, the “Workflow Permissions” in the repository settings should be reconfigured to “Read repository contents and packages permissions” instead of “Read and write permissions” to also make additional workflows secure by default, even when a permissions section is not explicitly configured.