### PR TITLE
Add build provenance attestation to the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,10 @@ jobs:
     permissions:
       # contents:write is required to upload the binaries to the release.
       contents: write
+      # id-token:write is required for build provenance attestation.
+      id-token: write
+      # attestations:write is required for build provenance attestation.
+      attestations: write
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -49,6 +53,10 @@ jobs:
               --detach-sign \
               --output pie.phar.asc \
               pie.phar
+      - name: Generate build provenance attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: '${{ github.workspace }}/pie.phar'
       - name: Upload binaries to release
         uses: softprops/action-gh-release@v2
         if: ${{startsWith(github.ref, 'refs/tags/') }}


### PR DESCRIPTION
This PR builds upon #127 and includes that one as a subset. I will rebase it after #127 is merged.

-------------------

This attestation proves that a given pie.phar was created by the release.yml workflow running for a specific commit.

Verification is possible using the `gh` CLI as follows:

    gh attestation verify --owner php pie.phar

For the test in my fork, the output looked like this:

    $ gh attestation verify --owner TimWolla pie.phar
    Loaded digest sha256:0dc7f9c88341fc1beac5746658e4a859a1abe8b3f6a62aa9f10c9ec39ff42b53 for file://pie.phar
    Loaded 2 attestations from GitHub API
    ✓ Verification succeeded!

    sha256:0dc7f9c88341fc1beac5746658e4a859a1abe8b3f6a62aa9f10c9ec39ff42b53 was attested by:
    REPO              PREDICATE_TYPE                  WORKFLOW
    TimWolla/php-pie  https://slsa.dev/provenance/v1  .github/workflows/release.yml@refs/tags/release-action-build-provenance-1
    TimWolla/php-pie  https://slsa.dev/provenance/v1  .github/workflows/release.yml@refs/heads/release-action-build-provenance