### PR TITLE
Add missing dependencies to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,11 @@
         "php": "8.1.*||8.2.*||8.3.*||8.4.*",
         "ext-zip": "*",
         "composer/composer": "dev-main",
+        "composer/pcre": "^3.3.2",
+        "composer/semver": "^3.4.3",
         "fidry/cpu-core-counter": "^1.2",
         "illuminate/container": "^10.48.25",
+        "psr/container": "^2.0.2",
         "symfony/console": "^6.4.15",
         "symfony/process": "^6.4.15",
         "webmozart/assert": "^1.11"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cb8ec13e5bf5b137b5b78a0e0f1cf961",
+    "content-hash": "b05bade5eae7d8c4d44fc4298428b1cb",
     "packages": [
         {
             "name": "composer/ca-bundle",


### PR DESCRIPTION
Code from these packages is explicitly referenced in PIE itself, but previously these packages were only required transitively through other dependencies.