### PR TITLE
Trim warnings and deprecations from output when invoking PHP in `PhpBinaryPath`

### DIFF
--- a/features/install-extensions.feature
+++ b/features/install-extensions.feature
@@ -22,6 +22,11 @@ Feature: Extensions can be installed with Behat
     When I run a command to build an extension
     Then the extension should have been built
 
+  Example: An extension can be built with warnings at PHP startup
+    Given I use the "-d extension=invalid_extension.so" PHP arguments
+    When I run a command to build an extension
+    Then the extension should have been built
+
   Example: An extension can be built with configure options
     When I run a command to build an extension with configure options
     Then the extension should have been built with options

--- a/features/install-extensions.feature
+++ b/features/install-extensions.feature
@@ -23,7 +23,7 @@ Feature: Extensions can be installed with Behat
     Then the extension should have been built
 
   Example: An extension can be built with warnings at PHP startup
-    Given I use the "-d extension=invalid_extension.so" PHP arguments
+    Given I have an invalid extension installed
     When I run a command to build an extension
     Then the extension should have been built
 

--- a/src/Platform/TargetPhp/PhpBinaryPath.php
+++ b/src/Platform/TargetPhp/PhpBinaryPath.php
@@ -20,6 +20,7 @@ use function assert;
 use function dirname;
 use function explode;
 use function file_exists;
+use function implode;
 use function is_dir;
 use function is_executable;
 use function preg_match;
@@ -58,7 +59,7 @@ class PhpBinaryPath
 
         // This is somewhat of a rudimentary check that the target PHP really is a PHP instance; not sure why you
         // WOULDN'T want to use a real PHP, but this should stop obvious hiccups at least (rather than for security)
-        $testOutput = Process::run([$phpBinaryPath, '-r', 'echo "PHP";']);
+        $testOutput = self::cleanWarningAndDeprecationsFromOutput(Process::run([$phpBinaryPath, '-r', 'echo "PHP";']));
 
         if ($testOutput !== 'PHP') {
             throw Exception\InvalidPhpBinaryPath::fromInvalidPhpBinary($phpBinaryPath);
@@ -116,7 +117,7 @@ class PhpBinaryPath
      */
     public function extensions(): array
     {
-        $extVersionsList = Process::run([
+        $extVersionsList = self::cleanWarningAndDeprecationsFromOutput(Process::run([
             $this->phpBinaryPath,
             '-r',
             <<<'PHP'
@@ -139,7 +140,7 @@ echo implode("\n", array_map(
     $extVersions
 ));
 PHP,
-        ]);
+        ]));
 
         $pairs = array_map(
             static fn (string $row) => explode(':', $row),
@@ -154,11 +155,11 @@ PHP,
 
     public function operatingSystem(): OperatingSystem
     {
-        $winOrNot = Process::run([
+        $winOrNot = self::cleanWarningAndDeprecationsFromOutput(Process::run([
             $this->phpBinaryPath,
             '-r',
             'echo \\defined(\'PHP_WINDOWS_VERSION_BUILD\') ? \'win\' : \'not\';',
-        ]);
+        ]));
         Assert::stringNotEmpty($winOrNot, 'Could not determine PHP version');
 
         return $winOrNot === 'win' ? OperatingSystem::Windows : OperatingSystem::NonWindows;
@@ -167,11 +168,11 @@ PHP,
     /** @return non-empty-string */
     public function version(): string
     {
-        $phpVersion = Process::run([
+        $phpVersion = self::cleanWarningAndDeprecationsFromOutput(Process::run([
             $this->phpBinaryPath,
             '-r',
             'echo PHP_MAJOR_VERSION . "." . PHP_MINOR_VERSION . "." . PHP_RELEASE_VERSION;',
-        ]);
+        ]));
         Assert::stringNotEmpty($phpVersion, 'Could not determine PHP version');
 
         // normalizing the version will throw an exception if it is not a valid version
@@ -183,11 +184,11 @@ PHP,
     /** @return non-empty-string */
     public function majorMinorVersion(): string
     {
-        $phpVersion = Process::run([
+        $phpVersion = self::cleanWarningAndDeprecationsFromOutput(Process::run([
             $this->phpBinaryPath,
             '-r',
             'echo PHP_MAJOR_VERSION . "." . PHP_MINOR_VERSION;',
-        ]);
+        ]));
         Assert::stringNotEmpty($phpVersion, 'Could not determine PHP version');
 
         // normalizing the version will throw an exception if it is not a valid version
@@ -198,11 +199,11 @@ PHP,
 
     public function machineType(): Architecture
     {
-        $phpMachineType = Process::run([
+        $phpMachineType = self::cleanWarningAndDeprecationsFromOutput(Process::run([
             $this->phpBinaryPath,
             '-r',
             'echo php_uname("m");',
-        ]);
+        ]));
         Assert::stringNotEmpty($phpMachineType, 'Could not determine PHP machine type');
 
         return Architecture::parseArchitecture($phpMachineType);
@@ -210,11 +211,11 @@ PHP,
 
     public function phpIntSize(): int
     {
-        $phpIntSize = Process::run([
+        $phpIntSize = self::cleanWarningAndDeprecationsFromOutput(Process::run([
             $this->phpBinaryPath,
             '-r',
             'echo PHP_INT_SIZE;',
-        ]);
+        ]));
         Assert::stringNotEmpty($phpIntSize, 'Could not fetch PHP_INT_SIZE');
         Assert::same($phpIntSize, (string) (int) $phpIntSize, 'PHP_INT_SIZE was not an integer processed %2$s from %s');
 
@@ -224,10 +225,10 @@ PHP,
     /** @return non-empty-string */
     public function phpinfo(): string
     {
-        $phpInfo = Process::run([
+        $phpInfo = self::cleanWarningAndDeprecationsFromOutput(Process::run([
             $this->phpBinaryPath,
             '-i',
-        ]);
+        ]));
 
         Assert::stringNotEmpty($phpInfo, sprintf('Could not run phpinfo using %s', $this->phpBinaryPath));
 
@@ -248,7 +249,7 @@ PHP,
     /** @param non-empty-string $phpConfig */
     public static function fromPhpConfigExecutable(string $phpConfig): self
     {
-        $phpExecutable = Process::run([$phpConfig, '--php-binary']);
+        $phpExecutable = self::cleanWarningAndDeprecationsFromOutput(Process::run([$phpConfig, '--php-binary']));
         Assert::stringNotEmpty($phpExecutable, 'Could not find path to PHP executable.');
 
         self::assertValidLookingPhpBinary($phpExecutable);
@@ -272,5 +273,20 @@ PHP,
         self::assertValidLookingPhpBinary($phpExecutable);
 
         return new self($phpExecutable, null);
+    }
+
+    private static function cleanWarningAndDeprecationsFromOutput(string $testOutput): string
+    {
+        $testOutput = explode("\n", $testOutput);
+
+        foreach ($testOutput as $key => $line) {
+            if (! preg_match('/^(Deprecated|Warning):/', $line)) {
+                continue;
+            }
+
+            unset($testOutput[$key]);
+        }
+
+        return implode("\n", $testOutput);
     }
 }

--- a/test/behaviour/CliContext.php
+++ b/test/behaviour/CliContext.php
@@ -12,12 +12,15 @@ use Symfony\Component\Process\Process;
 use Webmozart\Assert\Assert;
 
 use function array_merge;
+use function explode;
 
 /** @psalm-api */
 class CliContext implements Context
 {
     private string|null $output = null;
     private int|null $exitCode  = null;
+    /** @var list<string> */
+    private array $phpArguments = [];
 
     #[When('I run a command to download the latest version of an extension')]
     public function iRunACommandToDownloadTheLatestVersionOfAnExtension(): void
@@ -34,7 +37,7 @@ class CliContext implements Context
     /** @param list<non-empty-string> $command */
     public function runPieCommand(array $command): void
     {
-        $pieCommand = array_merge(['php', 'bin/pie'], $command);
+        $pieCommand = array_merge(['php', ...$this->phpArguments, 'bin/pie'], $command);
 
         $proc = (new Process($pieCommand))->mustRun();
 
@@ -127,5 +130,11 @@ class CliContext implements Context
         }
 
         Assert::regex($this->output, '#Install complete: [-_a-zA-Z0-9/]+/example_pie_extension.so#');
+    }
+
+    #[When('I use the :phpArguments PHP arguments')]
+    public function iUsePhpArguments(string $phpArguments): void
+    {
+        $this->phpArguments = explode(' ', $phpArguments);
     }
 }

--- a/test/behaviour/CliContext.php
+++ b/test/behaviour/CliContext.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Php\PieBehaviourTest;
 
 use Behat\Behat\Context\Context;
+use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Step\When;
 use Composer\Util\Platform;
@@ -12,7 +13,6 @@ use Symfony\Component\Process\Process;
 use Webmozart\Assert\Assert;
 
 use function array_merge;
-use function explode;
 
 /** @psalm-api */
 class CliContext implements Context
@@ -132,9 +132,9 @@ class CliContext implements Context
         Assert::regex($this->output, '#Install complete: [-_a-zA-Z0-9/]+/example_pie_extension.so#');
     }
 
-    #[When('I use the :phpArguments PHP arguments')]
-    public function iUsePhpArguments(string $phpArguments): void
+    #[Given('I have an invalid extension installed')]
+    public function iHaveAnInvalidExtensionInstalled(): void
     {
-        $this->phpArguments = explode(' ', $phpArguments);
+        $this->phpArguments = ['-d', 'extension=invalid_extension'];
     }
 }


### PR DESCRIPTION
Fix #146 

Adds a way to trim `Deprecated:` and `Warning:` from output. This is not only limited to `assertValidLookingPhpBinary`, but to all PHP subprocess invocation.

Unfortunately, warning messages are sent to `stdout`, not `stderr`.

The cleaning only happens during some setup/validation step of the current env, and the deprecations and warnings are still being displayed to the user when compiling the extension. This way, there's no "sneaky hiding" of error:

![image](https://github.com/user-attachments/assets/9954fb30-a642-49ff-b3e0-edf7740d6cba)

I added a parameter to the `Process::run()` method, but if we don't want to add it, the output could also be directly cleaned in the `PhpBinaryPath`. Indeed, I'm not _100%_ happy of this parameter, which is really "PHP-subprocess-related" in a class that is not limited to PHP subprocesses.