### PR TITLE
Download Git submodules

### DIFF
--- a/src/ComposerIntegration/InstallAndBuildProcess.php
+++ b/src/ComposerIntegration/InstallAndBuildProcess.php
@@ -10,7 +10,12 @@ use Php\Pie\Building\Build;
 use Php\Pie\DependencyResolver\Package;
 use Php\Pie\Downloading\DownloadedPackage;
 use Php\Pie\Installing\Install;
+use Php\Pie\Platform\Git\Exception\InvalidGitBinaryPath;
+use Php\Pie\Platform\Git\GitBinaryPath;
 
+use function file_exists;
+use function implode;
+use function rtrim;
 use function sprintf;
 
 /** @internal This is not public API for PIE, so should not be depended upon unless you accept the risk of BC breaks */
@@ -42,6 +47,27 @@ class InstallAndBuildProcess
             $downloadedPackage->package->prettyNameAndVersion(),
             $downloadedPackage->extractedSourcePath,
         ));
+
+        if (file_exists(rtrim($downloadedPackage->extractedSourcePath, '/') . '/.gitmodules')) {
+            try {
+                $output->writeln(sprintf(
+                    '<info>Found .gitmodules file in</info> %s<info>, fetching submodules...</info>',
+                    $downloadedPackage->extractedSourcePath,
+                ));
+
+                $git              = GitBinaryPath::fromGitBinaryPath('/opt/homebrew/bin/git');
+                $clonedSubmodules = $git->fetchSubmodules($downloadedPackage->extractedSourcePath);
+
+                $output->writeln(sprintf(
+                    '<info>Cloned submodules:</info> %s',
+                    implode(', ', $clonedSubmodules),
+                ));
+            } catch (InvalidGitBinaryPath $exception) {
+                $output->writeln('<error>Could not find a valid git binary path to clone submodules.</error>');
+
+                throw $exception;
+            }
+        }
 
         $this->installedJsonMetadata->addDownloadMetadata(
             $composer,

--- a/src/Platform/Git/Exception/InvalidGitBinaryPath.php
+++ b/src/Platform/Git/Exception/InvalidGitBinaryPath.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\Pie\Platform\Git\Exception;
+
+use RuntimeException;
+
+use function sprintf;
+
+class InvalidGitBinaryPath extends RuntimeException
+{
+    public static function fromNonExistentGitBinary(string $phpBinaryPath): self
+    {
+        return new self(sprintf(
+            'The git binary at "%s" does not exist',
+            $phpBinaryPath,
+        ));
+    }
+
+    public static function fromNonExecutableGitBinary(string $phpBinaryPath): self
+    {
+        return new self(sprintf(
+            'The git binary at "%s" is not executable',
+            $phpBinaryPath,
+        ));
+    }
+
+    public static function fromInvalidGitBinary(string $phpBinaryPath): self
+    {
+        return new self(sprintf(
+            'The git binary at "%s" does not appear to be a git binary',
+            $phpBinaryPath,
+        ));
+    }
+}

--- a/src/Platform/Git/GitBinaryPath.php
+++ b/src/Platform/Git/GitBinaryPath.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\Pie\Platform\Git;
+
+use Composer\Util\Platform;
+use Php\Pie\Util\Process;
+use RuntimeException;
+
+use function array_filter;
+use function array_map;
+use function array_merge;
+use function explode;
+use function file_exists;
+use function file_get_contents;
+use function is_executable;
+use function preg_match;
+use function rtrim;
+use function trim;
+
+/**
+ * @internal This is not public API for PIE, so should not be depended upon unless you accept the risk of BC breaks
+ *
+ * @immutable
+ */
+class GitBinaryPath
+{
+    private function __construct(
+        public readonly string $gitBinaryPath,
+    ) {
+    }
+
+    /** @param non-empty-string $gitBinary */
+    public static function fromGitBinaryPath(string $gitBinary): self
+    {
+        self::assertValidLookingGitBinary($gitBinary);
+
+        return new self($gitBinary);
+    }
+
+    /** @return array<string> The list of cloned submodules */
+    public function fetchSubmodules(string $path): array
+    {
+        $modulesPath = rtrim($path, '/') . '/.gitmodules';
+
+        if (! file_exists($modulesPath)) {
+            throw new RuntimeException('No .gitmodules file found in the specified path.');
+        }
+
+        $content = file_get_contents($modulesPath);
+        if ($content === false) {
+            throw new RuntimeException('Unable to read .gitmodules file.');
+        }
+
+        $modules = $this->parseGitModules($content);
+
+        if (! $modules) {
+            return [];
+        }
+
+        return $this->processModules($modules, $path);
+    }
+
+    /**
+     * @param string $content Raw content of .gitmodules file
+     *
+     * @return array<Submodule> List of parsed modules
+     */
+    private function parseGitModules(string $content): array
+    {
+        $lines       = array_filter(array_map('trim', explode("\n", $content)));
+        $modules     = [];
+        $currentName = null;
+        $currentPath = '';
+        $currentUrl  = '';
+
+        $modulePattern = '/^\[submodule "(?P<name>[^"]+)"]$/';
+        $configPattern = '/^(?P<key>path|url)\s*=\s*(?P<value>.+)$/';
+
+        foreach ($lines as $line) {
+            // do we enter a new module?
+            if (preg_match($modulePattern, $line, $matches)) {
+                if ($currentName !== null) {
+                    $modules[] = new Submodule($currentPath, $currentUrl);
+                }
+
+                $currentName = $matches['name'];
+                $currentPath = '';
+                $currentUrl  = '';
+
+                continue;
+            }
+
+            if ($currentName === null || ! preg_match($configPattern, $line, $matches)) {
+                continue;
+            }
+
+            if ($matches['key'] === 'path') {
+                $currentPath = trim($matches['value']);
+            } elseif ($matches['key'] === 'url') {
+                $currentUrl = trim($matches['value']);
+            }
+        }
+
+        if ($currentName !== null) {
+            $modules[] = new Submodule($currentPath, $currentUrl);
+        }
+
+        return $modules;
+    }
+
+    /**
+     * Process the parsed modules by cloning them and handling recursive submodules.
+     *
+     * @param non-empty-array<Submodule> $modules List of parsed modules
+     *
+     * @return array<array-key, string> The list of cloned submodules
+     */
+    private function processModules(array $modules, string $basePath): array
+    {
+        $clonedModules = [];
+
+        foreach ($modules as $module) {
+            if (! $module->path || ! $module->url) {
+                // incomplete module, skip
+                continue;
+            }
+
+            $targetPath = rtrim($basePath, '/') . '/' . $module->path;
+
+            Process::run([$this->gitBinaryPath, 'clone', $module->url, $targetPath], $basePath, timeout: null);
+            $clonedModules[] = $module->url;
+
+            if (! file_exists($targetPath . '/.gitmodules')) {
+                continue;
+            }
+
+            $clonedModules = array_merge($clonedModules, $this->fetchSubmodules($targetPath));
+        }
+
+        return $clonedModules;
+    }
+
+    private static function assertValidLookingGitBinary(string $gitBinary): void
+    {
+        if (! file_exists($gitBinary)) {
+            throw Exception\InvalidGitBinaryPath::fromNonExistentgitBinary($gitBinary);
+        }
+
+        if (! Platform::isWindows() && ! is_executable($gitBinary)) {
+            throw Exception\InvalidGitBinaryPath::fromNonExecutableGitBinary($gitBinary);
+        }
+
+        $output = Process::run([$gitBinary, '--version']);
+
+        if (! preg_match('/git version \d+\.\d+\.\d+/', $output)) {
+            throw Exception\InvalidGitBinaryPath::fromInvalidGitBinary($gitBinary);
+        }
+    }
+}

--- a/src/Platform/Git/Submodule.php
+++ b/src/Platform/Git/Submodule.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\Pie\Platform\Git;
+
+/**
+ * @internal This is not public API for PIE, so should not be depended upon unless you accept the risk of BC breaks
+ *
+ * @immutable
+ */
+final class Submodule
+{
+    public function __construct(
+        public readonly string $path,
+        public readonly string $url,
+    ) {
+    }
+}

--- a/test/assets/fake-git.sh
+++ b/test/assets/fake-git.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "Hah! I am not really Git.";

--- a/test/unit/Platform/Git/GitBinaryPathTest.php
+++ b/test/unit/Platform/Git/GitBinaryPathTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\PieUnitTest\Platform\Git;
+
+use Composer\Util\Platform;
+use Php\Pie\Platform\Git\Exception\InvalidGitBinaryPath;
+use Php\Pie\Platform\Git\GitBinaryPath;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(GitBinaryPath::class)]
+class GitBinaryPathTest extends TestCase
+{
+    private const FAKE_GIT_EXECUTABLE = __DIR__ . '/../../../assets/fake-git.sh';
+
+    public function testNonExistentPhpBinaryIsRejected(): void
+    {
+        $this->expectException(InvalidGitBinaryPath::class);
+        $this->expectExceptionMessage('does not exist');
+        GitBinaryPath::fromGitBinaryPath(__DIR__ . '/path/to/a/non/existent/git/binary');
+    }
+
+    public function testNonExecutablePhpBinaryIsRejected(): void
+    {
+        if (Platform::isWindows()) {
+            self::markTestSkipped('is_executable always returns false on Windows');
+        }
+
+        $this->expectException(InvalidGitBinaryPath::class);
+        $this->expectExceptionMessage('is not executable');
+        GitBinaryPath::fromGitBinaryPath(__FILE__);
+    }
+
+    public function testInvalidGitBinaryIsRejected(): void
+    {
+        $this->expectException(InvalidGitBinaryPath::class);
+        $this->expectExceptionMessage('does not appear to be a git binary');
+        GitBinaryPath::fromGitBinaryPath(self::FAKE_GIT_EXECUTABLE);
+    }
+}


### PR DESCRIPTION
Fix #39

As stated in the issue, the .git isn't present in the ZIP archived downloaded from Github. This makes not possible to use `git submodules update...`.

Here is the approach I propose: manually parse the .gitmodules (which isn't a complicated format so it works well), then recursively go through those modules and `git clone` each of them.

Try this out with : `bin/pie build mongodb/mongodb-extension`. Note that you may still have an error with this particular extension, but it is not related to this dev. But that's the only extension I found for now that uses submodules 😄 

It would be nice to update `asgrim/example-pie-extension` to add a `.gitmodules` to test this in the behavioral tests.

<img width="1198" alt="Capture d’écran 2024-12-23 à 11 52 36" src="https://github.com/user-attachments/assets/8648ad44-6f18-4bc3-a207-137825eb63bd" />
