### PR TITLE
Allow composer to ask for credentials

### DIFF
--- a/src/ComposerIntegration/MinimalHelperSet.php
+++ b/src/ComposerIntegration/MinimalHelperSet.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\Pie\ComposerIntegration;
+
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Webmozart\Assert\Assert;
+
+class MinimalHelperSet extends HelperSet
+{
+    public function __construct(array $helpers = [])
+    {
+        Assert::isInstanceOf(
+            $helpers['question'] ?? null,
+            QuestionHelper::class,
+            'The question option must be an instance of %2$s, got %s'
+        );
+
+        parent::__construct($helpers);
+    }
+}

--- a/src/ComposerIntegration/MinimalHelperSet.php
+++ b/src/ComposerIntegration/MinimalHelperSet.php
@@ -8,14 +8,16 @@ use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Webmozart\Assert\Assert;
 
+/** @internal This is not public API for PIE, so should not be depended upon unless you accept the risk of BC breaks */
 class MinimalHelperSet extends HelperSet
 {
-    public function __construct(array $helpers = [])
+    /** @param array{question: QuestionHelper} $helpers */
+    public function __construct(array $helpers)
     {
         Assert::isInstanceOf(
             $helpers['question'] ?? null,
             QuestionHelper::class,
-            'The question option must be an instance of %2$s, got %s'
+            'The question option must be an instance of %2$s, got %s',
         );
 
         parent::__construct($helpers);

--- a/src/ComposerIntegration/QuieterConsoleIO.php
+++ b/src/ComposerIntegration/QuieterConsoleIO.php
@@ -7,7 +7,6 @@ namespace Php\Pie\ComposerIntegration;
 use Closure;
 use Composer\IO\ConsoleIO;
 use Composer\IO\IOInterface;
-use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -21,7 +20,7 @@ class QuieterConsoleIO extends ConsoleIO
     /** @var string[] */
     public array $errors = [];
 
-    public function __construct(InputInterface $input, OutputInterface $output, HelperSet $helperSet)
+    public function __construct(InputInterface $input, OutputInterface $output, MinimalHelperSet $helperSet)
     {
         parent::__construct($input, $output, $helperSet);
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -25,7 +25,6 @@ use Php\Pie\Installing\Install;
 use Php\Pie\Installing\UnixInstall;
 use Php\Pie\Installing\WindowsInstall;
 use Psr\Container\ContainerInterface;
-use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;

--- a/src/Container.php
+++ b/src/Container.php
@@ -14,6 +14,7 @@ use Php\Pie\Command\DownloadCommand;
 use Php\Pie\Command\InfoCommand;
 use Php\Pie\Command\InstallCommand;
 use Php\Pie\Command\ShowCommand;
+use Php\Pie\ComposerIntegration\MinimalHelperSet;
 use Php\Pie\ComposerIntegration\QuieterConsoleIO;
 use Php\Pie\DependencyResolver\DependencyResolver;
 use Php\Pie\DependencyResolver\ResolveDependencyWithComposer;
@@ -25,6 +26,7 @@ use Php\Pie\Installing\UnixInstall;
 use Php\Pie\Installing\WindowsInstall;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
@@ -50,7 +52,11 @@ final class Container
             return new QuieterConsoleIO(
                 $container->get(InputInterface::class),
                 $container->get(OutputInterface::class),
-                new HelperSet(),
+                new MinimalHelperSet(
+                    [
+                        'question' => new QuestionHelper(),
+                    ],
+                ),
             );
         });
 

--- a/test/unit/ComposerIntegration/MinimalHelperSetTest.php
+++ b/test/unit/ComposerIntegration/MinimalHelperSetTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\PieUnitTest\ComposerIntegration;
+
+use Php\Pie\ComposerIntegration\MinimalHelperSet;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use Symfony\Component\Console\Helper\QuestionHelper;
+
+#[CoversClass(MinimalHelperSet::class)]
+class MinimalHelperSetTest extends TestCase
+{
+    public function testHappyPath(): void
+    {
+        $this->expectNotToPerformAssertions();
+        new MinimalHelperSet(['question' => $this->createMock(QuestionHelper::class)]);
+    }
+
+    public function testQuestionOptionIsMissing(): void
+    {
+        $this->expectExceptionMessage('The question option must be an instance of Symfony\Component\Console\Helper\QuestionHelper, got NULL');
+        new MinimalHelperSet([]);
+    }
+
+    public function testQuestionOptionIsNotAQuestionHelper(): void
+    {
+        $this->expectExceptionMessage('The question option must be an instance of Symfony\Component\Console\Helper\QuestionHelper, got stdClass');
+        new MinimalHelperSet(['question' => new stdClass()]);
+    }
+}

--- a/test/unit/ComposerIntegration/MinimalHelperSetTest.php
+++ b/test/unit/ComposerIntegration/MinimalHelperSetTest.php
@@ -7,7 +7,6 @@ namespace Php\PieUnitTest\ComposerIntegration;
 use Php\Pie\ComposerIntegration\MinimalHelperSet;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use stdClass;
 use Symfony\Component\Console\Helper\QuestionHelper;
 
 #[CoversClass(MinimalHelperSet::class)]
@@ -17,17 +16,5 @@ class MinimalHelperSetTest extends TestCase
     {
         $this->expectNotToPerformAssertions();
         new MinimalHelperSet(['question' => $this->createMock(QuestionHelper::class)]);
-    }
-
-    public function testQuestionOptionIsMissing(): void
-    {
-        $this->expectExceptionMessage('The question option must be an instance of Symfony\Component\Console\Helper\QuestionHelper, got NULL');
-        new MinimalHelperSet([]);
-    }
-
-    public function testQuestionOptionIsNotAQuestionHelper(): void
-    {
-        $this->expectExceptionMessage('The question option must be an instance of Symfony\Component\Console\Helper\QuestionHelper, got stdClass');
-        new MinimalHelperSet(['question' => new stdClass()]);
     }
 }

--- a/test/unit/ComposerIntegration/QuieterConsoleIOTest.php
+++ b/test/unit/ComposerIntegration/QuieterConsoleIOTest.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Php\PieUnitTest\ComposerIntegration;
 
 use Composer\IO\IOInterface;
+use Php\Pie\ComposerIntegration\MinimalHelperSet;
 use Php\Pie\ComposerIntegration\QuieterConsoleIO;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -29,7 +29,7 @@ final class QuieterConsoleIOTest extends TestCase
             ->method('write')
             ->with('Oh no');
 
-        $io = new QuieterConsoleIO($symfonyInput, $symfonyOutput, new HelperSet([]));
+        $io = new QuieterConsoleIO($symfonyInput, $symfonyOutput, $this->createMock(MinimalHelperSet::class));
         $io->writeError('Oh no');
 
         self::assertSame(['Oh no'], $io->errors);
@@ -47,7 +47,7 @@ final class QuieterConsoleIOTest extends TestCase
             ->method('write')
             ->with(['Oh no', 'Bad things']);
 
-        $io = new QuieterConsoleIO($symfonyInput, $symfonyOutput, new HelperSet([]));
+        $io = new QuieterConsoleIO($symfonyInput, $symfonyOutput, $this->createMock(MinimalHelperSet::class));
         $io->writeError(['Oh no', 'Bad things']);
 
         self::assertSame(['Oh no', 'Bad things'], $io->errors);
@@ -64,7 +64,7 @@ final class QuieterConsoleIOTest extends TestCase
             ->expects(self::never())
             ->method('write');
 
-        $io = new QuieterConsoleIO($symfonyInput, $symfonyOutput, new HelperSet([]));
+        $io = new QuieterConsoleIO($symfonyInput, $symfonyOutput, $this->createMock(MinimalHelperSet::class));
         $io->writeError('Oh no');
 
         self::assertSame(['Oh no'], $io->errors);
@@ -105,7 +105,7 @@ final class QuieterConsoleIOTest extends TestCase
         };
         $symfonyOutput->setVerbosity($symfonyVerbosity);
 
-        $io = new QuieterConsoleIO($symfonyInput, $symfonyOutput, new HelperSet([]));
+        $io = new QuieterConsoleIO($symfonyInput, $symfonyOutput, $this->createMock(MinimalHelperSet::class));
 
         $io->write('Quiet', verbosity: IOInterface::QUIET);
         $io->write('Normal', verbosity: IOInterface::NORMAL);

--- a/test/unit/DependencyResolver/UnableToResolveRequirementTest.php
+++ b/test/unit/DependencyResolver/UnableToResolveRequirementTest.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Php\PieUnitTest\DependencyResolver;
 
 use Composer\Package\PackageInterface;
+use Php\Pie\ComposerIntegration\MinimalHelperSet;
 use Php\Pie\ComposerIntegration\QuieterConsoleIO;
 use Php\Pie\DependencyResolver\RequestedPackageAndVersion;
 use Php\Pie\DependencyResolver\UnableToResolveRequirement;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -42,7 +42,7 @@ final class UnableToResolveRequirementTest extends TestCase
         $io = new QuieterConsoleIO(
             $this->createMock(InputInterface::class),
             $this->createMock(OutputInterface::class),
-            $this->createMock(HelperSet::class),
+            $this->createMock(MinimalHelperSet::class),
         );
         $io->writeError('message1');
         $io->writeError('message2', true, QuieterConsoleIO::VERY_VERBOSE);
@@ -58,7 +58,7 @@ final class UnableToResolveRequirementTest extends TestCase
         $io = new QuieterConsoleIO(
             $this->createMock(InputInterface::class),
             $this->createMock(OutputInterface::class),
-            $this->createMock(HelperSet::class),
+            $this->createMock(MinimalHelperSet::class),
         );
         $io->writeError('message1');
         $io->writeError('message2', true, QuieterConsoleIO::VERY_VERBOSE);


### PR DESCRIPTION
Fixes https://github.com/php/pie/issues/89

I have created the value object `MinimalHelperSet` so we can always ensure that the `question` option exist.