### PR TITLE
Enhance "show" command with PIE metadata

### DIFF
--- a/src/Command/ShowCommand.php
+++ b/src/Command/ShowCommand.php
@@ -4,11 +4,22 @@ declare(strict_types=1);
 
 namespace Php\Pie\Command;
 
+use Composer\Package\BasePackage;
+use Composer\Package\CompletePackageInterface;
+use Php\Pie\ComposerIntegration\PieComposerFactory;
+use Php\Pie\ComposerIntegration\PieComposerRequest;
+use Php\Pie\DependencyResolver\Package;
+use Php\Pie\Platform\TargetPlatform;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function array_combine;
+use function array_filter;
+use function array_key_exists;
+use function array_map;
 use function array_walk;
 use function sprintf;
 
@@ -18,6 +29,12 @@ use function sprintf;
 )]
 final class ShowCommand extends Command
 {
+    public function __construct(
+        private readonly ContainerInterface $container,
+    ) {
+        parent::__construct();
+    }
+
     public function configure(): void
     {
         parent::configure();
@@ -29,15 +46,69 @@ final class ShowCommand extends Command
     {
         $targetPlatform = CommandHelper::determineTargetPlatformFromInputs($input, $output);
 
-        $extensions = $targetPlatform->phpBinaryPath->extensions();
+        $piePackages          = $this->buildListOfPieInstalledPackages($output, $targetPlatform);
+        $phpEnabledExtensions = $targetPlatform->phpBinaryPath->extensions();
+
         $output->writeln("\n" . '<info>Loaded extensions:</info>');
         array_walk(
-            $extensions,
-            static function (string $version, string $name) use ($output): void {
-                $output->writeln(sprintf('%s:%s', $name, $version));
+            $phpEnabledExtensions,
+            static function (string $version, string $phpExtensionName) use ($output, $piePackages): void {
+                if (! array_key_exists($phpExtensionName, $piePackages)) {
+                    $output->writeln(sprintf('  <comment>%s:%s</comment>', $phpExtensionName, $version));
+
+                    return;
+                }
+
+                // @todo determine if installed ext has drifted using the PIE checksum
+
+                $piePackage = $piePackages[$phpExtensionName];
+                $output->writeln(sprintf(
+                    '  <info>%s:%s</info> (from <info>%s</info>)',
+                    $phpExtensionName,
+                    $version,
+                    $piePackage->prettyNameAndVersion(),
+                ));
             },
         );
 
         return Command::SUCCESS;
+    }
+
+    /** @return array<non-empty-string, Package> */
+    private function buildListOfPieInstalledPackages(
+        OutputInterface $output,
+        TargetPlatform $targetPlatform,
+    ): array {
+        $composerInstalledPackages = array_map(
+            static function (CompletePackageInterface $package): Package {
+                return Package::fromComposerCompletePackage($package);
+            },
+            array_filter(
+                PieComposerFactory::createPieComposer(
+                    $this->container,
+                    PieComposerRequest::noOperation(
+                        $output,
+                        $targetPlatform,
+                    ),
+                )
+                    ->getRepositoryManager()
+                    ->getLocalRepository()
+                    ->getPackages(),
+                static function (BasePackage $basePackage): bool {
+                    return $basePackage instanceof CompletePackageInterface;
+                },
+            ),
+        );
+
+        return array_combine(
+            array_map(
+            /** @return non-empty-string */
+                static function (Package $package): string {
+                    return $package->extensionName->name();
+                },
+                $composerInstalledPackages,
+            ),
+            $composerInstalledPackages,
+        );
     }
 }

--- a/src/Command/ShowCommand.php
+++ b/src/Command/ShowCommand.php
@@ -6,9 +6,12 @@ namespace Php\Pie\Command;
 
 use Composer\Package\BasePackage;
 use Composer\Package\CompletePackageInterface;
+use Php\Pie\BinaryFile;
 use Php\Pie\ComposerIntegration\PieComposerFactory;
 use Php\Pie\ComposerIntegration\PieComposerRequest;
+use Php\Pie\ComposerIntegration\PieInstalledJsonMetadataKeys;
 use Php\Pie\DependencyResolver\Package;
+use Php\Pie\Platform\OperatingSystem;
 use Php\Pie\Platform\TargetPlatform;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -21,8 +24,13 @@ use function array_filter;
 use function array_key_exists;
 use function array_map;
 use function array_walk;
+use function file_exists;
 use function sprintf;
+use function substr;
 
+use const DIRECTORY_SEPARATOR;
+
+/** @psalm-import-type PieMetadata from PieInstalledJsonMetadataKeys */
 #[AsCommand(
     name: 'show',
     description: 'List the installed modules and their versions.',
@@ -48,30 +56,70 @@ final class ShowCommand extends Command
 
         $piePackages          = $this->buildListOfPieInstalledPackages($output, $targetPlatform);
         $phpEnabledExtensions = $targetPlatform->phpBinaryPath->extensions();
+        $extensionPath        = $targetPlatform->phpBinaryPath->extensionPath();
+        $extensionEnding      = $targetPlatform->operatingSystem === OperatingSystem::Windows ? '.dll' : '.so';
 
         $output->writeln("\n" . '<info>Loaded extensions:</info>');
         array_walk(
             $phpEnabledExtensions,
-            static function (string $version, string $phpExtensionName) use ($output, $piePackages): void {
+            static function (string $version, string $phpExtensionName) use ($output, $piePackages, $extensionPath, $extensionEnding): void {
                 if (! array_key_exists($phpExtensionName, $piePackages)) {
                     $output->writeln(sprintf('  <comment>%s:%s</comment>', $phpExtensionName, $version));
 
                     return;
                 }
 
-                // @todo determine if installed ext has drifted using the PIE checksum
-
                 $piePackage = $piePackages[$phpExtensionName];
+
                 $output->writeln(sprintf(
-                    '  <info>%s:%s</info> (from <info>%s</info>)',
+                    '  <info>%s:%s</info> (from 🥧 <info>%s</info>%s)',
                     $phpExtensionName,
                     $version,
                     $piePackage->prettyNameAndVersion(),
+                    self::verifyChecksumInformation(
+                        $extensionPath,
+                        $phpExtensionName,
+                        $extensionEnding,
+                        PieInstalledJsonMetadataKeys::pieMetadataFromComposerPackage($piePackage->composerPackage),
+                    ),
                 ));
             },
         );
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * @param PieMetadata $installedJsonMetadata
+     * @psalm-param '.dll'|'.so' $extensionEnding
+     */
+    private static function verifyChecksumInformation(
+        string $extensionPath,
+        string $phpExtensionName,
+        string $extensionEnding,
+        array $installedJsonMetadata,
+    ): string {
+        $expectedConventionalBinaryPath = $extensionPath . DIRECTORY_SEPARATOR . $phpExtensionName . $extensionEnding;
+
+        // The extension may not be in the usual path (since you can specify a full path to an extension in the INI file)
+        if (! file_exists($expectedConventionalBinaryPath)) {
+            return '';
+        }
+
+        $pieExpectedBinaryPath = array_key_exists(PieInstalledJsonMetadataKeys::InstalledBinary->value, $installedJsonMetadata) ? $installedJsonMetadata[PieInstalledJsonMetadataKeys::InstalledBinary->value] : null;
+        $pieExpectedChecksum   = array_key_exists(PieInstalledJsonMetadataKeys::BinaryChecksum->value, $installedJsonMetadata) ? $installedJsonMetadata[PieInstalledJsonMetadataKeys::BinaryChecksum->value] : null;
+
+        // Some other kind of mismatch of file path, or we don't have a stored checksum available
+        if ($expectedConventionalBinaryPath !== $pieExpectedBinaryPath || $pieExpectedChecksum === null) {
+            return '';
+        }
+
+        $actualInstalledBinary = BinaryFile::fromFileWithSha256Checksum($expectedConventionalBinaryPath);
+        if ($actualInstalledBinary->checksum !== $pieExpectedChecksum) {
+            return ' ⚠️ was ' . substr($actualInstalledBinary->checksum, 0, 8) . '..., expected ' . substr($pieExpectedChecksum, 0, 8) . '...';
+        }
+
+        return ' ✅ ' . substr($pieExpectedChecksum, 0, 8) . '...';
     }
 
     /** @return array<non-empty-string, Package> */

--- a/src/Command/ShowCommand.php
+++ b/src/Command/ShowCommand.php
@@ -119,7 +119,7 @@ final class ShowCommand extends Command
             return ' ⚠️ was ' . substr($actualInstalledBinary->checksum, 0, 8) . '..., expected ' . substr($pieExpectedChecksum, 0, 8) . '...';
         }
 
-        return ' ✅ ' . substr($pieExpectedChecksum, 0, 8) . '...';
+        return ' ✅';
     }
 
     /** @return array<non-empty-string, Package> */

--- a/src/ComposerIntegration/PieComposerRequest.php
+++ b/src/ComposerIntegration/PieComposerRequest.php
@@ -27,4 +27,23 @@ final class PieComposerRequest
         public readonly bool $attemptToSetupIniFile,
     ) {
     }
+
+    /**
+     * Useful for when we don't want to perform any "write" style operations;
+     * for example just reading metadata about the installed system.
+     */
+    public static function noOperation(
+        OutputInterface $pieOutput,
+        TargetPlatform $targetPlatform,
+    ): self {
+        return new PieComposerRequest(
+            $pieOutput,
+            $targetPlatform,
+            new RequestedPackageAndVersion('null', null),
+            PieOperation::Resolve,
+            [],
+            null,
+            false,
+        );
+    }
 }

--- a/src/ComposerIntegration/PieInstalledJsonMetadataKeys.php
+++ b/src/ComposerIntegration/PieInstalledJsonMetadataKeys.php
@@ -4,7 +4,29 @@ declare(strict_types=1);
 
 namespace Php\Pie\ComposerIntegration;
 
-/** @internal This is not public API for PIE, so should not be depended upon unless you accept the risk of BC breaks */
+use Composer\Package\CompletePackageInterface;
+
+use function array_column;
+use function array_key_exists;
+use function is_string;
+
+/**
+ * @internal This is not public API for PIE, so should not be depended upon unless you accept the risk of BC breaks
+ *
+ * @psalm-type PieMetadata = array{
+ *     pie-target-platform-php-path?: non-empty-string,
+ *     pie-target-platform-php-config-path?: non-empty-string,
+ *     pie-target-platform-php-version?: non-empty-string,
+ *     pie-target-platform-php-thread-safety?: non-empty-string,
+ *     pie-target-platform-php-windows-compiler?: non-empty-string,
+ *     pie-target-platform-architecture?: non-empty-string,
+ *     pie-configure-options?: non-empty-string,
+ *     pie-built-binary?: non-empty-string,
+ *     pie-installed-binary-checksum?: non-empty-string,
+ *     pie-installed-binary?: non-empty-string,
+ *     pie-phpize-binary?: non-empty-string,
+ * }
+ */
 enum PieInstalledJsonMetadataKeys: string
 {
     case TargetPlatformPhpPath            = 'pie-target-platform-php-path';
@@ -18,4 +40,26 @@ enum PieInstalledJsonMetadataKeys: string
     case BinaryChecksum                   = 'pie-installed-binary-checksum';
     case InstalledBinary                  = 'pie-installed-binary';
     case PhpizeBinary                     = 'pie-phpize-binary';
+
+    /** @return PieMetadata */
+    public static function pieMetadataFromComposerPackage(CompletePackageInterface $composerPackage): array
+    {
+        $composerPackageExtras = $composerPackage->getExtra();
+
+        $onlyPieExtras = [];
+
+        foreach (array_column(self::cases(), 'value') as $pieMetadataKey) {
+            if (
+                ! array_key_exists($pieMetadataKey, $composerPackageExtras)
+                || ! is_string($composerPackageExtras[$pieMetadataKey])
+                || $composerPackageExtras[$pieMetadataKey] === ''
+            ) {
+                continue;
+            }
+
+            $onlyPieExtras[$pieMetadataKey] = $composerPackageExtras[$pieMetadataKey];
+        }
+
+        return $onlyPieExtras;
+    }
 }

--- a/src/Platform/TargetPhp/PhpBinaryPath.php
+++ b/src/Platform/TargetPhp/PhpBinaryPath.php
@@ -225,11 +225,11 @@ PHP,
 
     public function operatingSystemFamily(): OperatingSystemFamily
     {
-        $output = Process::run([
+        $output = self::cleanWarningAndDeprecationsFromOutput(Process::run([
             $this->phpBinaryPath,
             '-r',
             'echo PHP_OS_FAMILY;',
-        ]);
+        ]));
 
         $osFamily = OperatingSystemFamily::tryFrom(strtolower(trim($output)));
         Assert::notNull($osFamily, 'Could not determine operating system family');

--- a/test/unit/ComposerIntegration/PieInstalledJsonMetadataKeysTest.php
+++ b/test/unit/ComposerIntegration/PieInstalledJsonMetadataKeysTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\PieUnitTest\ComposerIntegration;
+
+use Composer\Package\CompletePackageInterface;
+use Php\Pie\ComposerIntegration\PieInstalledJsonMetadataKeys;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PieInstalledJsonMetadataKeys::class)]
+final class PieInstalledJsonMetadataKeysTest extends TestCase
+{
+    public function testPieMetadataFromComposerPackageWithEmptyExtra(): void
+    {
+        $composerPackage = $this->createMock(CompletePackageInterface::class);
+        $composerPackage->expects(self::once())
+            ->method('getExtra')
+            ->willReturn([]);
+
+        self::assertSame([], PieInstalledJsonMetadataKeys::pieMetadataFromComposerPackage($composerPackage));
+    }
+
+    public function testPieMetadataFromComposerPackageWithPopulatedExtra(): void
+    {
+        $composerPackage = $this->createMock(CompletePackageInterface::class);
+        $composerPackage->expects(self::once())
+            ->method('getExtra')
+            ->willReturn([
+                PieInstalledJsonMetadataKeys::InstalledBinary->value => '/path/to/some/file',
+                PieInstalledJsonMetadataKeys::BinaryChecksum->value => 'some-checksum-value',
+                'something else' => 'hopefully this does not make it in',
+            ]);
+
+        self::assertEqualsCanonicalizing(
+            [
+                PieInstalledJsonMetadataKeys::InstalledBinary->value => '/path/to/some/file',
+                PieInstalledJsonMetadataKeys::BinaryChecksum->value => 'some-checksum-value',
+            ],
+            PieInstalledJsonMetadataKeys::pieMetadataFromComposerPackage($composerPackage),
+        );
+    }
+}


### PR DESCRIPTION
```
$ bin/pie show --with-php-config=/path/to/php-config
You are running PHP 8.3.15
Target PHP installation: 8.3.14 ts, on Linux/OSX/etc x86_64 (from /path/to/php)

Loaded extensions:
  Core:8.3.14
  date:8.3.14
  ...
  example_pie_extension:0.1.0 (from 🥧 asgrim/example-pie-extension:2.0.2 ⚠️ was 07251244..., expected 10725124...)
  mongodb:1.20.1 (from 🥧 mongodb/mongodb-extension:1.20.1 ✅ 13ae0552...)
  ...
```