### PR TITLE
Fix access to the GITHUB_TOKEN

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,8 +10,6 @@ permissions:
 jobs:
   unit-tests:
     runs-on: ${{ matrix.operating-system }}
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       matrix:
         operating-system:
@@ -28,6 +26,8 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: intl, sodium, zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v4
       # temporarily remove Psalm until ready for PHP 8.4
       - name: remove psalm
@@ -37,9 +37,13 @@ jobs:
       - name: Run PHPUnit on Windows
         if: matrix.operating-system == 'windows-latest'
         run: vendor/bin/phpunit
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run PHPUnit on non-Windows
         if: matrix.operating-system != 'windows-latest'
         run: sudo vendor/bin/phpunit
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   behaviour-tests:
     runs-on: ${{ matrix.operating-system }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,6 +10,8 @@ permissions:
 jobs:
   unit-tests:
     runs-on: ${{ matrix.operating-system }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       matrix:
         operating-system:
@@ -26,8 +28,6 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: intl, sodium, zip
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v4
       # temporarily remove Psalm until ready for PHP 8.4
       - name: remove psalm

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,7 +29,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v4
-      - run: composer config --global github-oauth.github.com ${{ secrets.GITHUB_TOKEN }}
       # temporarily remove Psalm until ready for PHP 8.4
       - name: remove psalm
         if: matrix.php-versions == '8.4'


### PR DESCRIPTION
Closes https://github.com/php/pie/issues/169

The main issue was that while this [test](https://github.com/php/pie/pull/171/files#diff-ee4139668bc93757e55104b542b5de1e68322ed1fcf463b523835f5aa781dd82R65-R74) was trying to use the `GITHUB_TOKEN` environment variable, the variable was scoped to be used in a specific command only. I moved the env to the top so it can be accessed by all the commands in the step.

Furthermore, this line `- run: composer config --global github-oauth.github.com ${{ secrets.GITHUB_TOKEN }}` is removed because this is handled by the `setup-php` action. For references please check https://github.com/shivammathur/setup-php/blob/main/src/scripts/tools/add_tools.sh#L64 and https://github.com/shivammathur/setup-php?tab=readme-ov-file#wrench-tools-support