### PR TITLE
Add repository management commands

### DIFF
--- a/.github/docs/Dockerfile
+++ b/.github/docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/roave/docbooktool:1.16.0 AS builder
+FROM ghcr.io/roave/docbooktool:1.19.0 AS builder
 
 COPY ./.github/docs/templates /docs-src/templates
 COPY ./docs /docs-src/book

--- a/.github/docs/templates/online.twig
+++ b/.github/docs/templates/online.twig
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>PIE Documentation</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.22.0/themes/prism.css" rel="stylesheet" />
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.2/css/all.min.css" rel="stylesheet" />
     <style>
         .selected {
             background-color: #7A86B8;
@@ -82,6 +84,10 @@
      * @param {string} title
      */
     function loadDocBookNavigation(title) {
+        document.querySelectorAll('table').forEach((table) => {
+            table.classList.add("table");
+        })
+
         /**
          * @param {NodeListOf<HTMLElement>} unselectedListElements
          * @param {HTMLElement} selectedListElement
@@ -219,5 +225,7 @@
 
     loadDocBookNavigation("PIE Documentation");
 </script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.js"></script>
 </body>
 </html>

--- a/.github/docs/templates/online.twig
+++ b/.github/docs/templates/online.twig
@@ -15,6 +15,41 @@
         .hidden {
             display: none;
         }
+        .markdown-alert {
+            border-left: 0.25em solid black;
+            padding: 1em 1em 0.25em;
+            background-color: #f7f7f7;
+        }
+        .markdown-alert-note {
+            border-left-color: #0d68d5;
+        }
+        .markdown-alert-note .markdown-alert-title {
+            color: #0d68d5;
+        }
+        .markdown-alert-tip {
+            border-left-color: #188337;
+        }
+        .markdown-alert-tip .markdown-alert-title {
+            color: #188337;
+        }
+        .markdown-alert-important {
+            border-left-color: #7844d6;
+        }
+        .markdown-alert-important .markdown-alert-title {
+            color: #7844d6;
+        }
+        .markdown-alert-warning {
+            border-left-color: #a67003;
+        }
+        .markdown-alert-warning .markdown-alert-title {
+            color: #a67003;
+        }
+        .markdown-alert-caution {
+            border-left-color: #d61c28;
+        }
+        .markdown-alert-caution .markdown-alert-title {
+            color: #d61c28;
+        }
     </style>
 </head>
 <body>

--- a/bin/pie
+++ b/bin/pie
@@ -9,6 +9,9 @@ use Php\Pie\Command\BuildCommand;
 use Php\Pie\Command\DownloadCommand;
 use Php\Pie\Command\InfoCommand;
 use Php\Pie\Command\InstallCommand;
+use Php\Pie\Command\RepositoryAddCommand;
+use Php\Pie\Command\RepositoryListCommand;
+use Php\Pie\Command\RepositoryRemoveCommand;
 use Php\Pie\Command\ShowCommand;
 use Php\Pie\Util\PieVersion;
 use Symfony\Component\Console\Application;
@@ -31,6 +34,9 @@ $application->setCommandLoader(new ContainerCommandLoader(
         'install' => InstallCommand::class,
         'info' => InfoCommand::class,
         'show' => ShowCommand::class,
+        'repository:list' => RepositoryListCommand::class,
+        'repository:add' => RepositoryAddCommand::class,
+        'repository:remove' => RepositoryRemoveCommand::class,
     ]
 ));
 

--- a/docs/extension-maintainers.md
+++ b/docs/extension-maintainers.md
@@ -137,7 +137,7 @@ specify a default value in the `configure-options` definition.
 The `build-path` setting may be used if your source code is not in the root
 of your repository. For example, if your repository structure is like:
 
-```
+```text
 /
   docs/
   src/

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -197,7 +197,7 @@ functionality, or to provide paths to libraries not automatically detected.
 In order to determine what configure options are available for an extension,
 you may use `pie info <vendor>/<package>` which will return a list, such as:
 
-```
+```text
 Configure options:
     --enable-some-functionality  (whether to enable some additional functionality provided)
     --with-some-library-name=?  (Path for some-library)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -37,7 +37,7 @@ COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
 
 Instead of `bin` tag (which represents latest binary-only image) you can also use explicit version (in `x.y.z-bin` format). Use [GitHub registry](https://ghcr.io/php/pie) to find available tags.
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > Binary-only images don't include PHP runtime so you can't use them for _running_ PIE. This is just an alternative way of distributing PHAR file, you still need to satisfy PIE's runtime requirements on your own.
 
 #### Example of PIE working in a Dockerfile
@@ -215,6 +215,43 @@ pie install example/some-extension --with-some-library-name=/path/to/the/lib --e
 
 ### Configuring the INI file
 
-At the moment, PIE does not configure the INI file, although this improvement
-is planned soon. In the meantime, you must enable the extension after installing
-by adding a line such as `extension=foo` to your `php.ini`.
+PIE will automatically try to enable the extension by adding `extension=...` or
+`zend_extension=...` in the appropriate INI file. If you want to disable this
+behaviour, pass the `--skip-enable-extension` flag to your `pie install`
+command. The following techniques are used to attempt to enable the extension:
+
+ * `phpenmod`, if using the deb.sury.org distribution
+ * `docker-php-ext-enable` if using Docker's PHP image
+ * Add a new file to the "additional .ini file" path, if configured
+ * Append to the standard php.ini, if configured
+
+If none of these techniques work, or you used the `--skip-enable-extension`
+flag, PIE will warn you that the extension was not enabled, and will note that
+you must enable the extension yourself.
+
+### Adding non-Packagist.org repositories
+
+Sometimes you may want to install an extension from a package repository other
+than Packagist.org (such as [Private Packagist](https://packagist.com/)), or
+from a local directory. Since PIE is based heavily on Composer, it is possible
+to use some other repository types:
+
+* `pie repository:add [--with-php-config=...] path /path/to/your/local/extension`
+* `pie repository:add [--with-php-config=...] vcs https://github.com/youruser/yourextension`
+* `pie repository:add [--with-php-config=...] composer https://repo.packagist.com/your-private-packagist/`
+
+The `repository:*` commands all support the optional `--with-php-config` flag
+to allow you to specify which PHP installation to use (for example, if you have
+multiple PHP installations on one machine). The above added repositories can be
+removed too, using the inverse `repository:remove` commands:
+
+* `pie repository:remove [--with-php-config=...] /path/to/your/local/extension`
+* `pie repository:remove [--with-php-config=...] https://github.com/youruser/yourextension`
+* `pie repository:remove [--with-php-config=...] https://repo.packagist.com/your-private-packagist/`
+
+Note you do not need to specify the repository type in `repository:remove`,
+just the URL.
+
+You can list the repositories for the target PHP installation with:
+
+* `pie repository:list [--with-php-config=...]`

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -239,6 +239,7 @@ to use some other repository types:
 * `pie repository:add [--with-php-config=...] path /path/to/your/local/extension`
 * `pie repository:add [--with-php-config=...] vcs https://github.com/youruser/yourextension`
 * `pie repository:add [--with-php-config=...] composer https://repo.packagist.com/your-private-packagist/`
+* `pie repository:add [--with-php-config=...] composer packagist.org`
 
 The `repository:*` commands all support the optional `--with-php-config` flag
 to allow you to specify which PHP installation to use (for example, if you have
@@ -248,6 +249,7 @@ removed too, using the inverse `repository:remove` commands:
 * `pie repository:remove [--with-php-config=...] /path/to/your/local/extension`
 * `pie repository:remove [--with-php-config=...] https://github.com/youruser/yourextension`
 * `pie repository:remove [--with-php-config=...] https://repo.packagist.com/your-private-packagist/`
+* `pie repository:remove [--with-php-config=...] packagist.org`
 
 Note you do not need to specify the repository type in `repository:remove`,
 just the URL.

--- a/features/install-extensions.feature
+++ b/features/install-extensions.feature
@@ -1,4 +1,4 @@
-Feature: Extensions can be installed with Behat
+Feature: Extensions can be installed with PIE
 
   Example: The latest version of an extension can be downloaded
     When I run a command to download the latest version of an extension

--- a/features/manage-repositories.feature
+++ b/features/manage-repositories.feature
@@ -1,0 +1,11 @@
+Feature: Package repositories can be managed with PIE
+
+  Example: A package repository can be added
+    Given no repositories have previously been added
+    When I add a package repository
+    Then I should see the package repository can be used by PIE
+
+  Example: A package repository can be removed
+    Given I have previously added a package repository
+    When I remove the package repository
+    Then I should see the package repository is not used by PIE

--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -274,7 +274,16 @@ final class CommandHelper
 
         foreach ($composer->getRepositoryManager()->getRepositories() as $repo) {
             if ($repo instanceof ComposerRepository) {
-                $output->writeln('  - Packagist (cannot be removed)');
+                $repoConfig = $repo->getRepoConfig();
+
+                $repoUrl = array_key_exists('url', $repoConfig) && is_string($repoConfig['url']) && $repoConfig['url'] !== '' ? $repoConfig['url'] : null;
+
+                if ($repoUrl === 'https://repo.packagist.org') {
+                    $output->writeln('  - Packagist');
+                    continue;
+                }
+
+                $output->writeln(sprintf('  - Composer (%s)', $repoUrl ?? 'no url?'));
                 continue;
             }
 

--- a/src/Command/RepositoryAddCommand.php
+++ b/src/Command/RepositoryAddCommand.php
@@ -27,7 +27,7 @@ final class RepositoryAddCommand extends Command
     private const ARG_TYPE = 'type';
     private const ARG_URL  = 'url';
 
-    private const ALLOWED_TYPES = ['vcs', 'path'];
+    private const ALLOWED_TYPES = ['vcs', 'path', 'composer'];
 
     public function __construct(
         private readonly ContainerInterface $container,
@@ -44,12 +44,12 @@ final class RepositoryAddCommand extends Command
         $this->addArgument(
             self::ARG_TYPE,
             InputArgument::REQUIRED,
-            'Specify the type of the repository, e.g. vcs, path',
+            'Specify the type of the repository, e.g. vcs, path, composer',
         );
         $this->addArgument(
             self::ARG_URL,
             InputArgument::REQUIRED,
-            'Specify the URL of the repository, e.g. a Github/Gitlab URL, or a filesystem path',
+            'Specify the URL of the repository, e.g. a Github/Gitlab URL, a filesystem path, or Private Packagist URL',
         );
         $this->addUsage('lol');
     }
@@ -60,7 +60,7 @@ final class RepositoryAddCommand extends Command
         $pieJsonFilename = Platform::getPieJsonFilename($targetPlatform);
 
         $type = (string) $input->getArgument(self::ARG_TYPE);
-        /** @psalm-var 'vcs'|'path' $type */
+        /** @psalm-var 'vcs'|'path'|'composer' $type */
         Assert::inArray($type, self::ALLOWED_TYPES);
 
         $url = $originalUrl = (string) $input->getArgument(self::ARG_URL);

--- a/src/Command/RepositoryAddCommand.php
+++ b/src/Command/RepositoryAddCommand.php
@@ -52,7 +52,6 @@ final class RepositoryAddCommand extends Command
             InputArgument::REQUIRED,
             'Specify the URL of the repository, e.g. a Github/Gitlab URL, a filesystem path, or Private Packagist URL',
         );
-        $this->addUsage('lol');
     }
 
     public function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Command/RepositoryAddCommand.php
+++ b/src/Command/RepositoryAddCommand.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\Pie\Command;
+
+use Php\Pie\ComposerIntegration\PieComposerFactory;
+use Php\Pie\ComposerIntegration\PieComposerRequest;
+use Php\Pie\ComposerIntegration\PieJsonEditor;
+use Php\Pie\Platform;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Webmozart\Assert\Assert;
+
+use function realpath;
+
+#[AsCommand(
+    name: 'repository:add',
+    description: 'Add a new repository for packages that PIE can use.',
+)]
+final class RepositoryAddCommand extends Command
+{
+    private const ARG_TYPE = 'type';
+    private const ARG_URL  = 'url';
+
+    private const ALLOWED_TYPES = ['vcs', 'path'];
+
+    public function __construct(
+        private readonly ContainerInterface $container,
+    ) {
+        parent::__construct();
+    }
+
+    public function configure(): void
+    {
+        parent::configure();
+
+        CommandHelper::configurePhpConfigOptions($this);
+
+        $this->addArgument(
+            self::ARG_TYPE,
+            InputArgument::REQUIRED,
+            'Specify the type of the repository, e.g. vcs, path',
+        );
+        $this->addArgument(
+            self::ARG_URL,
+            InputArgument::REQUIRED,
+            'Specify the URL of the repository, e.g. a Github/Gitlab URL, or a filesystem path',
+        );
+        $this->addUsage('lol');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $targetPlatform  = CommandHelper::determineTargetPlatformFromInputs($input, $output);
+        $pieJsonFilename = Platform::getPieJsonFilename($targetPlatform);
+
+        $type = (string) $input->getArgument(self::ARG_TYPE);
+        /** @psalm-var 'vcs'|'path' $type */
+        Assert::inArray($type, self::ALLOWED_TYPES);
+
+        $url = $originalUrl = (string) $input->getArgument(self::ARG_URL);
+
+        if ($type === 'path') {
+            $url = realpath($originalUrl);
+        }
+
+        Assert::stringNotEmpty($url, 'Could not resolve ' . $originalUrl . ' to a real path');
+
+        (new PieJsonEditor($pieJsonFilename))->addRepository($type, $url);
+
+        CommandHelper::listRepositories(
+            PieComposerFactory::createPieComposer(
+                $this->container,
+                PieComposerRequest::noOperation(
+                    $output,
+                    CommandHelper::determineTargetPlatformFromInputs($input, $output),
+                ),
+            ),
+            $output,
+        );
+
+        return 0;
+    }
+}

--- a/src/Command/RepositoryListCommand.php
+++ b/src/Command/RepositoryListCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\Pie\Command;
+
+use Php\Pie\ComposerIntegration\PieComposerFactory;
+use Php\Pie\ComposerIntegration\PieComposerRequest;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'repository:list',
+    description: 'List the package repositories that PIE uses.',
+)]
+final class RepositoryListCommand extends Command
+{
+    public function __construct(
+        private readonly ContainerInterface $container,
+    ) {
+        parent::__construct();
+    }
+
+    public function configure(): void
+    {
+        parent::configure();
+
+        CommandHelper::configurePhpConfigOptions($this);
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        CommandHelper::listRepositories(
+            PieComposerFactory::createPieComposer(
+                $this->container,
+                PieComposerRequest::noOperation(
+                    $output,
+                    CommandHelper::determineTargetPlatformFromInputs($input, $output),
+                ),
+            ),
+            $output,
+        );
+
+        return 0;
+    }
+}

--- a/src/Command/RepositoryRemoveCommand.php
+++ b/src/Command/RepositoryRemoveCommand.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\Pie\Command;
+
+use Php\Pie\ComposerIntegration\PieComposerFactory;
+use Php\Pie\ComposerIntegration\PieComposerRequest;
+use Php\Pie\ComposerIntegration\PieJsonEditor;
+use Php\Pie\Platform;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Webmozart\Assert\Assert;
+
+#[AsCommand(
+    name: 'repository:remove',
+    description: 'Remove a repository for packages that PIE can use.',
+)]
+final class RepositoryRemoveCommand extends Command
+{
+    private const ARG_URL = 'url';
+
+    public function __construct(
+        private readonly ContainerInterface $container,
+    ) {
+        parent::__construct();
+    }
+
+    public function configure(): void
+    {
+        parent::configure();
+
+        CommandHelper::configurePhpConfigOptions($this);
+
+        $this->addArgument(
+            self::ARG_URL,
+            InputArgument::REQUIRED,
+            'Specify the URL of the repository, e.g. a Github/Gitlab URL, or a filesystem path',
+        );
+        $this->addUsage('lol');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $targetPlatform  = CommandHelper::determineTargetPlatformFromInputs($input, $output);
+        $pieJsonFilename = Platform::getPieJsonFilename($targetPlatform);
+
+        $url = (string) $input->getArgument(self::ARG_URL);
+        Assert::stringNotEmpty($url);
+
+        (new PieJsonEditor($pieJsonFilename))->removeRepository($url);
+
+        CommandHelper::listRepositories(
+            PieComposerFactory::createPieComposer(
+                $this->container,
+                PieComposerRequest::noOperation(
+                    $output,
+                    CommandHelper::determineTargetPlatformFromInputs($input, $output),
+                ),
+            ),
+            $output,
+        );
+
+        return 0;
+    }
+}

--- a/src/Command/RepositoryRemoveCommand.php
+++ b/src/Command/RepositoryRemoveCommand.php
@@ -7,7 +7,6 @@ namespace Php\Pie\Command;
 use Php\Pie\ComposerIntegration\PieComposerFactory;
 use Php\Pie\ComposerIntegration\PieComposerRequest;
 use Php\Pie\ComposerIntegration\PieJsonEditor;
-use Php\Pie\Platform;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -47,17 +46,21 @@ final class RepositoryRemoveCommand extends Command
 
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        $targetPlatform  = CommandHelper::determineTargetPlatformFromInputs($input, $output);
-        $pieJsonFilename = Platform::getPieJsonFilename($targetPlatform);
+        $targetPlatform = CommandHelper::determineTargetPlatformFromInputs($input, $output);
+        $pieJsonEditor  = PieJsonEditor::fromTargetPlatform($targetPlatform);
 
         $url = (string) $input->getArgument(self::ARG_URL);
         Assert::stringNotEmpty($url);
 
         if (str_contains($url, 'packagist.org')) {
             // "removing packagist" is really just adding an exclusion
-            (new PieJsonEditor($pieJsonFilename))->excludePackagistOrg();
+            $pieJsonEditor
+                ->ensureExists()
+                ->excludePackagistOrg();
         } else {
-            (new PieJsonEditor($pieJsonFilename))->removeRepository($url);
+            $pieJsonEditor
+                ->ensureExists()
+                ->removeRepository($url);
         }
 
         CommandHelper::listRepositories(

--- a/src/Command/RepositoryRemoveCommand.php
+++ b/src/Command/RepositoryRemoveCommand.php
@@ -43,7 +43,6 @@ final class RepositoryRemoveCommand extends Command
             InputArgument::REQUIRED,
             'Specify the URL of the repository, e.g. a Github/Gitlab URL, or a filesystem path',
         );
-        $this->addUsage('lol');
     }
 
     public function execute(InputInterface $input, OutputInterface $output): int

--- a/src/ComposerIntegration/ComposerIntegrationHandler.php
+++ b/src/ComposerIntegration/ComposerIntegrationHandler.php
@@ -44,7 +44,7 @@ class ComposerIntegrationHandler
 
         // Write the new requirement to pie.json; because we later essentially just do a `composer install` using that file
         $pieComposerJson        = Platform::getPieJsonFilename($targetPlatform);
-        $pieJsonEditor          = new PieJsonEditor($pieComposerJson);
+        $pieJsonEditor          = PieJsonEditor::fromTargetPlatform($targetPlatform);
         $originalPieJsonContent = $pieJsonEditor->addRequire(
             $requestedPackageAndVersion->package,
             $recommendedRequireVersion !== '' ? $recommendedRequireVersion : '*',

--- a/src/ComposerIntegration/PieComposerFactory.php
+++ b/src/ComposerIntegration/PieComposerFactory.php
@@ -17,7 +17,6 @@ use Psr\Container\ContainerInterface;
 use Webmozart\Assert\Assert;
 
 use function file_exists;
-use function file_put_contents;
 use function mkdir;
 
 /** @internal This is not public API for PIE, so should not be depended upon unless you accept the risk of BC breaks */
@@ -60,12 +59,7 @@ class PieComposerFactory extends Factory
 
         $pieComposer = Platform::getPieJsonFilename($composerRequest->targetPlatform);
 
-        if (! file_exists($pieComposer)) {
-            file_put_contents(
-                $pieComposer,
-                "{\n}\n",
-            );
-        }
+        (new PieJsonEditor($pieComposer))->ensureExists();
 
         $io       = $container->get(QuieterConsoleIO::class);
         $composer = (new PieComposerFactory($container, $composerRequest))->createComposer(

--- a/src/ComposerIntegration/PieComposerFactory.php
+++ b/src/ComposerIntegration/PieComposerFactory.php
@@ -16,9 +16,6 @@ use Php\Pie\Platform;
 use Psr\Container\ContainerInterface;
 use Webmozart\Assert\Assert;
 
-use function file_exists;
-use function mkdir;
-
 /** @internal This is not public API for PIE, so should not be depended upon unless you accept the risk of BC breaks */
 class PieComposerFactory extends Factory
 {
@@ -51,15 +48,9 @@ class PieComposerFactory extends Factory
         ContainerInterface $container,
         PieComposerRequest $composerRequest,
     ): Composer {
-        $workDir = Platform::getPieWorkingDirectory($composerRequest->targetPlatform);
-
-        if (! file_exists($workDir)) {
-            mkdir($workDir, recursive: true);
-        }
-
         $pieComposer = Platform::getPieJsonFilename($composerRequest->targetPlatform);
 
-        (new PieJsonEditor($pieComposer))->ensureExists();
+        PieJsonEditor::fromTargetPlatform($composerRequest->targetPlatform)->ensureExists();
 
         $io       = $container->get(QuieterConsoleIO::class);
         $composer = (new PieComposerFactory($container, $composerRequest))->createComposer(

--- a/src/ComposerIntegration/PieJsonEditor.php
+++ b/src/ComposerIntegration/PieJsonEditor.php
@@ -10,6 +10,7 @@ use Composer\Json\JsonFile;
 use function file_exists;
 use function file_get_contents;
 use function file_put_contents;
+use function rtrim;
 use function str_replace;
 
 /** @internal This is not public API for PIE, so should not be depended upon unless you accept the risk of BC breaks */
@@ -125,6 +126,6 @@ class PieJsonEditor
 
     private function normaliseRepositoryName(string $url): string
     {
-        return str_replace('\\', '/', $url);
+        return rtrim(str_replace('\\', '/', $url), '/');
     }
 }

--- a/src/ComposerIntegration/PieJsonEditor.php
+++ b/src/ComposerIntegration/PieJsonEditor.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\Pie\ComposerIntegration;
+
+use Composer\Config\JsonConfigSource;
+use Composer\Json\JsonFile;
+use Composer\Json\JsonManipulator;
+use Php\Pie\Platform\TargetPlatform;
+
+use function file_exists;
+use function file_get_contents;
+use function file_put_contents;
+
+/** @internal This is not public API for PIE, so should not be depended upon unless you accept the risk of BC breaks */
+class PieJsonEditor
+{
+    public function __construct(private readonly string $pieJsonFilename)
+    {
+    }
+
+    /**
+     * Ensure the given `pie.json` exists; if it does not exist, create an
+     * empty but valid `pie.json`.
+     */
+    public function ensureExists(): void
+    {
+        if (file_exists($this->pieJsonFilename)) {
+            return;
+        }
+
+        file_put_contents(
+            $this->pieJsonFilename,
+            "{\n}\n",
+        );
+    }
+
+    /**
+     * Add a package to the `require` section of the given `pie.json`. Returns
+     * the original `pie.json` content, in case it needs to be restored later.
+     *
+     * @param non-empty-string $package
+     * @param non-empty-string $version
+     */
+    public function addRequire(string $package, string $version): string
+    {
+        $originalPieJsonContent = file_get_contents($this->pieJsonFilename);
+        $manipulator            = new JsonManipulator($originalPieJsonContent);
+        $manipulator->addLink('require', $package, $version, true);
+        file_put_contents($this->pieJsonFilename, $manipulator->getContents());
+
+        return $originalPieJsonContent;
+    }
+
+    public function revert(string $originalPieJsonContent): void
+    {
+        file_put_contents($this->pieJsonFilename, $originalPieJsonContent);
+    }
+}

--- a/src/ComposerIntegration/PieJsonEditor.php
+++ b/src/ComposerIntegration/PieJsonEditor.php
@@ -15,6 +15,8 @@ use function str_replace;
 /** @internal This is not public API for PIE, so should not be depended upon unless you accept the risk of BC breaks */
 class PieJsonEditor
 {
+    public const PACKAGIST_ORG_KEY = 'packagist.org';
+
     public function __construct(private readonly string $pieJsonFilename)
     {
     }
@@ -58,6 +60,20 @@ class PieJsonEditor
     public function revert(string $originalPieJsonContent): void
     {
         file_put_contents($this->pieJsonFilename, $originalPieJsonContent);
+    }
+
+    public function excludePackagistOrg(): string
+    {
+        $originalPieJsonContent = file_get_contents($this->pieJsonFilename);
+
+        (new JsonConfigSource(
+            new JsonFile(
+                $this->pieJsonFilename,
+            ),
+        ))
+            ->addRepository(self::PACKAGIST_ORG_KEY, false);
+
+        return $originalPieJsonContent;
     }
 
     /**

--- a/src/ComposerIntegration/PieJsonEditor.php
+++ b/src/ComposerIntegration/PieJsonEditor.php
@@ -6,11 +6,16 @@ namespace Php\Pie\ComposerIntegration;
 
 use Composer\Config\JsonConfigSource;
 use Composer\Json\JsonFile;
+use Php\Pie\Platform;
+use Php\Pie\Platform\TargetPlatform;
+use RuntimeException;
 
 use function file_exists;
 use function file_get_contents;
 use function file_put_contents;
+use function mkdir;
 use function rtrim;
+use function sprintf;
 use function str_replace;
 
 /** @internal This is not public API for PIE, so should not be depended upon unless you accept the risk of BC breaks */
@@ -18,24 +23,43 @@ class PieJsonEditor
 {
     public const PACKAGIST_ORG_KEY = 'packagist.org';
 
-    public function __construct(private readonly string $pieJsonFilename)
+    public function __construct(
+        private readonly string $pieJsonFilename,
+        private readonly string $pieWorkingDirectory,
+    ) {
+    }
+
+    public static function fromTargetPlatform(TargetPlatform $targetPlatform): self
     {
+        return new self(
+            Platform::getPieJsonFilename($targetPlatform),
+            Platform::getPieWorkingDirectory($targetPlatform),
+        );
     }
 
     /**
      * Ensure the given `pie.json` exists; if it does not exist, create an
      * empty but valid `pie.json`.
      */
-    public function ensureExists(): void
+    public function ensureExists(): self
     {
         if (file_exists($this->pieJsonFilename)) {
-            return;
+            return $this;
         }
 
-        file_put_contents(
-            $this->pieJsonFilename,
-            "{\n}\n",
-        );
+        if (! file_exists($this->pieWorkingDirectory)) {
+            mkdir($this->pieWorkingDirectory, recursive: true);
+        }
+
+        if (file_put_contents($this->pieJsonFilename, "{\n}\n") === false) {
+            throw new RuntimeException(sprintf(
+                'Failed to create pie.json in %s (working directory: %s)',
+                $this->pieJsonFilename,
+                $this->pieWorkingDirectory,
+            ));
+        }
+
+        return $this;
     }
 
     /**

--- a/src/ComposerIntegration/PieJsonEditor.php
+++ b/src/ComposerIntegration/PieJsonEditor.php
@@ -10,6 +10,7 @@ use Composer\Json\JsonFile;
 use function file_exists;
 use function file_get_contents;
 use function file_put_contents;
+use function str_replace;
 
 /** @internal This is not public API for PIE, so should not be depended upon unless you accept the risk of BC breaks */
 class PieJsonEditor
@@ -77,7 +78,7 @@ class PieJsonEditor
                 $this->pieJsonFilename,
             ),
         ))
-            ->addRepository($url, [
+            ->addRepository($this->normaliseRepositoryName($url), [
                 'type' => $type,
                 'url' => $url,
             ]);
@@ -101,8 +102,13 @@ class PieJsonEditor
                 $this->pieJsonFilename,
             ),
         ))
-            ->removeRepository($name);
+            ->removeRepository($this->normaliseRepositoryName($name));
 
         return $originalPieJsonContent;
+    }
+
+    private function normaliseRepositoryName(string $url): string
+    {
+        return str_replace('\\', '/', $url);
     }
 }

--- a/src/ComposerIntegration/PieJsonEditor.php
+++ b/src/ComposerIntegration/PieJsonEditor.php
@@ -63,8 +63,8 @@ class PieJsonEditor
      * Add a repository to the given `pie.json`. Returns the original
      * `pie.json` content, in case it needs to be restored later.
      *
-     * @param 'vcs'|'path'     $type
-     * @param non-empty-string $url
+     * @param 'vcs'|'path'|'composer' $type
+     * @param non-empty-string        $url
      */
     public function addRepository(
         string $type,

--- a/src/ComposerIntegration/PieJsonEditor.php
+++ b/src/ComposerIntegration/PieJsonEditor.php
@@ -63,12 +63,10 @@ class PieJsonEditor
      * Add a repository to the given `pie.json`. Returns the original
      * `pie.json` content, in case it needs to be restored later.
      *
-     * @param non-empty-string $name
      * @param 'vcs'|'path'     $type
      * @param non-empty-string $url
      */
     public function addRepository(
-        string $name,
         string $type,
         string $url,
     ): string {
@@ -79,10 +77,31 @@ class PieJsonEditor
                 $this->pieJsonFilename,
             ),
         ))
-            ->addRepository($name, [
+            ->addRepository($url, [
                 'type' => $type,
                 'url' => $url,
             ]);
+
+        return $originalPieJsonContent;
+    }
+
+    /**
+     * Remove a repository from the given `pie.json`. Returns the original
+     * `pie.json` content, in case it needs to be restored later.
+     *
+     * @param non-empty-string $name
+     */
+    public function removeRepository(
+        string $name,
+    ): string {
+        $originalPieJsonContent = file_get_contents($this->pieJsonFilename);
+
+        (new JsonConfigSource(
+            new JsonFile(
+                $this->pieJsonFilename,
+            ),
+        ))
+            ->removeRepository($name);
 
         return $originalPieJsonContent;
     }

--- a/src/Container.php
+++ b/src/Container.php
@@ -13,6 +13,9 @@ use Php\Pie\Command\BuildCommand;
 use Php\Pie\Command\DownloadCommand;
 use Php\Pie\Command\InfoCommand;
 use Php\Pie\Command\InstallCommand;
+use Php\Pie\Command\RepositoryAddCommand;
+use Php\Pie\Command\RepositoryListCommand;
+use Php\Pie\Command\RepositoryRemoveCommand;
 use Php\Pie\Command\ShowCommand;
 use Php\Pie\ComposerIntegration\MinimalHelperSet;
 use Php\Pie\ComposerIntegration\QuieterConsoleIO;
@@ -46,6 +49,9 @@ final class Container
         $container->singleton(InstallCommand::class);
         $container->singleton(InfoCommand::class);
         $container->singleton(ShowCommand::class);
+        $container->singleton(RepositoryListCommand::class);
+        $container->singleton(RepositoryAddCommand::class);
+        $container->singleton(RepositoryRemoveCommand::class);
 
         $container->singleton(QuieterConsoleIO::class, static function (ContainerInterface $container): QuieterConsoleIO {
             return new QuieterConsoleIO(

--- a/test/behaviour/CliContext.php
+++ b/test/behaviour/CliContext.php
@@ -146,4 +146,43 @@ class CliContext implements Context
     {
         $this->phpArguments = ['-d', 'extension=invalid_extension'];
     }
+
+    #[When('I add a package repository')]
+    public function iAddAPackageRepository(): void
+    {
+        $this->runPieCommand(['repository:add', 'path', __DIR__]);
+    }
+
+    #[Then('I should see the package repository can be used by PIE')]
+    public function iShouldSeeThePackageRepositoryCanBeUsedByPie(): void
+    {
+        Assert::notNull($this->output);
+        Assert::contains($this->output, 'Path Repository (' . __DIR__ . ')');
+    }
+
+    #[Given('I have previously added a package repository')]
+    public function iHavePreviouslyAddedAPackageRepository(): void
+    {
+        $this->noRepositoriesHavePreviouslyBeenAdded();
+        $this->iAddAPackageRepository();
+    }
+
+    #[Given('no repositories have previously been added')]
+    public function noRepositoriesHavePreviouslyBeenAdded(): void
+    {
+        $this->iRemoveThePackageRepository();
+    }
+
+    #[When('I remove the package repository')]
+    public function iRemoveThePackageRepository(): void
+    {
+        $this->runPieCommand(['repository:remove', __DIR__]);
+    }
+
+    #[Then('I should see the package repository is not used by PIE')]
+    public function iShouldSeeThePackageRepositoryIsNotUsedByPie(): void
+    {
+        Assert::notNull($this->output);
+        Assert::notContains($this->output, 'Path repository (' . __DIR__ . ')');
+    }
 }

--- a/test/integration/Command/RepositoryManagementCommandsTest.php
+++ b/test/integration/Command/RepositoryManagementCommandsTest.php
@@ -69,6 +69,26 @@ final class RepositoryManagementCommandsTest extends TestCase
         $this->assertRepositoryListDisplayed(['Packagist']);
     }
 
+    public function testPathRepositoriesWithTrailingSlashesCanBeManaged(): void
+    {
+        $this->assertRepositoryListDisplayed(['Packagist']);
+
+        $this->addCommand->execute([
+            'type' => 'path',
+            'url' => self::EXAMPLE_PATH_REPOSITORY_URL . '/',
+        ]);
+
+        $this->assertRepositoryListDisplayed(
+            [
+                'Path Repository (' . self::EXAMPLE_PATH_REPOSITORY_URL . ')',
+                'Packagist',
+            ],
+        );
+
+        $this->removeCommand->execute(['url' => self::EXAMPLE_PATH_REPOSITORY_URL . '/']);
+        $this->assertRepositoryListDisplayed(['Packagist']);
+    }
+
     public function testVcsRepositoriesCanBeManaged(): void
     {
         $this->assertRepositoryListDisplayed(['Packagist']);

--- a/test/integration/Command/RepositoryManagementCommandsTest.php
+++ b/test/integration/Command/RepositoryManagementCommandsTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\PieIntegrationTest\Command;
+
+use Php\Pie\Command\RepositoryAddCommand;
+use Php\Pie\Command\RepositoryListCommand;
+use Php\Pie\Command\RepositoryRemoveCommand;
+use Php\Pie\Container;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+use function array_filter;
+use function array_map;
+use function array_values;
+use function explode;
+use function str_starts_with;
+use function substr;
+
+use const PHP_EOL;
+
+#[CoversClass(RepositoryListCommand::class)]
+#[CoversClass(RepositoryAddCommand::class)]
+#[CoversClass(RepositoryRemoveCommand::class)]
+final class RepositoryManagementCommandsTest extends TestCase
+{
+    private const EXAMPLE_PATH_REPOSITORY_URL = __DIR__;
+    private const EXAMPLE_VCS_REPOSITORY_URL  = 'https://github.com/asgrim/example-pie-extension';
+
+    private CommandTester $listCommand;
+    private CommandTester $addCommand;
+    private CommandTester $removeCommand;
+
+    public function setUp(): void
+    {
+        $this->listCommand   = new CommandTester(Container::factory()->get(RepositoryListCommand::class));
+        $this->addCommand    = new CommandTester(Container::factory()->get(RepositoryAddCommand::class));
+        $this->removeCommand = new CommandTester(Container::factory()->get(RepositoryRemoveCommand::class));
+
+        $this->removeCommand->execute(['url' => self::EXAMPLE_PATH_REPOSITORY_URL]);
+        $this->removeCommand->execute(['url' => self::EXAMPLE_VCS_REPOSITORY_URL]);
+        $this->removeCommand->execute(['url' => self::EXAMPLE_VCS_REPOSITORY_URL . '.git']);
+    }
+
+    public function testPathRepositoriesCanBeManaged(): void
+    {
+        $this->assertRepositoryListDisplayed(['Packagist (cannot be removed)']);
+
+        $this->addCommand->execute([
+            'type' => 'path',
+            'url' => self::EXAMPLE_PATH_REPOSITORY_URL,
+        ]);
+
+        $this->assertRepositoryListDisplayed(
+            [
+                'Path Repository (' . self::EXAMPLE_PATH_REPOSITORY_URL . ')',
+                'Packagist (cannot be removed)',
+            ],
+        );
+
+        $this->removeCommand->execute(['url' => self::EXAMPLE_PATH_REPOSITORY_URL]);
+        $this->assertRepositoryListDisplayed(['Packagist (cannot be removed)']);
+    }
+
+    public function testVcsRepositoriesCanBeManaged(): void
+    {
+        $this->assertRepositoryListDisplayed(['Packagist (cannot be removed)']);
+
+        $this->addCommand->execute([
+            'type' => 'vcs',
+            'url' => self::EXAMPLE_VCS_REPOSITORY_URL,
+        ]);
+
+        $this->assertRepositoryListDisplayed(
+            [
+                'VCS Repository (' . self::EXAMPLE_VCS_REPOSITORY_URL . '.git)',
+                'Packagist (cannot be removed)',
+            ],
+        );
+
+        $this->removeCommand->execute(['url' => self::EXAMPLE_VCS_REPOSITORY_URL]);
+        $this->assertRepositoryListDisplayed(['Packagist (cannot be removed)']);
+    }
+
+    /** @param list<non-empty-string> $expectedRepositories */
+    private function assertRepositoryListDisplayed(array $expectedRepositories): void
+    {
+        $this->listCommand->execute([]);
+        $this->listCommand->assertCommandIsSuccessful();
+
+        $outputString = $this->listCommand->getDisplay();
+
+        self::assertEquals(
+            $expectedRepositories,
+            array_values(array_map(
+                static fn ($line) => substr($line, 4),
+                array_filter(
+                    explode(PHP_EOL, $outputString),
+                    static fn ($line): bool => str_starts_with($line, '  - '),
+                ),
+            )),
+        );
+    }
+}

--- a/test/integration/Command/RepositoryManagementCommandsTest.php
+++ b/test/integration/Command/RepositoryManagementCommandsTest.php
@@ -28,6 +28,7 @@ final class RepositoryManagementCommandsTest extends TestCase
 {
     private const EXAMPLE_PATH_REPOSITORY_URL = __DIR__;
     private const EXAMPLE_VCS_REPOSITORY_URL  = 'https://github.com/asgrim/example-pie-extension';
+    private const PACKAGIST_ORG_URL           = 'packagist.org';
 
     private CommandTester $listCommand;
     private CommandTester $addCommand;
@@ -39,6 +40,10 @@ final class RepositoryManagementCommandsTest extends TestCase
         $this->addCommand    = new CommandTester(Container::factory()->get(RepositoryAddCommand::class));
         $this->removeCommand = new CommandTester(Container::factory()->get(RepositoryRemoveCommand::class));
 
+        $this->addCommand->execute([
+            'type' => 'composer',
+            'url' => self::PACKAGIST_ORG_URL,
+        ]);
         $this->removeCommand->execute(['url' => self::EXAMPLE_PATH_REPOSITORY_URL]);
         $this->removeCommand->execute(['url' => self::EXAMPLE_VCS_REPOSITORY_URL]);
         $this->removeCommand->execute(['url' => self::EXAMPLE_VCS_REPOSITORY_URL . '.git']);
@@ -81,6 +86,21 @@ final class RepositoryManagementCommandsTest extends TestCase
         );
 
         $this->removeCommand->execute(['url' => self::EXAMPLE_VCS_REPOSITORY_URL]);
+        $this->assertRepositoryListDisplayed(['Packagist']);
+    }
+
+    public function testPackagistOrgCanBeManaged(): void
+    {
+        $this->assertRepositoryListDisplayed(['Packagist']);
+
+        $this->removeCommand->execute(['url' => self::PACKAGIST_ORG_URL]);
+
+        $this->assertRepositoryListDisplayed([]);
+
+        $this->addCommand->execute([
+            'type' => 'composer',
+            'url' => self::PACKAGIST_ORG_URL,
+        ]);
         $this->assertRepositoryListDisplayed(['Packagist']);
     }
 

--- a/test/integration/Command/RepositoryManagementCommandsTest.php
+++ b/test/integration/Command/RepositoryManagementCommandsTest.php
@@ -46,7 +46,7 @@ final class RepositoryManagementCommandsTest extends TestCase
 
     public function testPathRepositoriesCanBeManaged(): void
     {
-        $this->assertRepositoryListDisplayed(['Packagist (cannot be removed)']);
+        $this->assertRepositoryListDisplayed(['Packagist']);
 
         $this->addCommand->execute([
             'type' => 'path',
@@ -56,17 +56,17 @@ final class RepositoryManagementCommandsTest extends TestCase
         $this->assertRepositoryListDisplayed(
             [
                 'Path Repository (' . self::EXAMPLE_PATH_REPOSITORY_URL . ')',
-                'Packagist (cannot be removed)',
+                'Packagist',
             ],
         );
 
         $this->removeCommand->execute(['url' => self::EXAMPLE_PATH_REPOSITORY_URL]);
-        $this->assertRepositoryListDisplayed(['Packagist (cannot be removed)']);
+        $this->assertRepositoryListDisplayed(['Packagist']);
     }
 
     public function testVcsRepositoriesCanBeManaged(): void
     {
-        $this->assertRepositoryListDisplayed(['Packagist (cannot be removed)']);
+        $this->assertRepositoryListDisplayed(['Packagist']);
 
         $this->addCommand->execute([
             'type' => 'vcs',
@@ -76,12 +76,12 @@ final class RepositoryManagementCommandsTest extends TestCase
         $this->assertRepositoryListDisplayed(
             [
                 'VCS Repository (' . self::EXAMPLE_VCS_REPOSITORY_URL . '.git)',
-                'Packagist (cannot be removed)',
+                'Packagist',
             ],
         );
 
         $this->removeCommand->execute(['url' => self::EXAMPLE_VCS_REPOSITORY_URL]);
-        $this->assertRepositoryListDisplayed(['Packagist (cannot be removed)']);
+        $this->assertRepositoryListDisplayed(['Packagist']);
     }
 
     /** @param list<non-empty-string> $expectedRepositories */

--- a/test/unit/Command/CommandHelperTest.php
+++ b/test/unit/Command/CommandHelperTest.php
@@ -188,7 +188,11 @@ final class CommandHelperTest extends TestCase
     {
         $output = new BufferedOutput();
 
-        $composerRepo = $this->createMock(ComposerRepository::class);
+        $packagistRepo = $this->createMock(ComposerRepository::class);
+        $packagistRepo->method('getRepoConfig')->willReturn(['url' => 'https://repo.packagist.org']);
+
+        $privatePackagistRepo = $this->createMock(ComposerRepository::class);
+        $privatePackagistRepo->method('getRepoConfig')->willReturn(['url' => 'https://repo.packagist.com/example']);
 
         $githubRepoDriver = $this->createMock(GitHubDriver::class);
         $githubRepoDriver->method('getUrl')->willReturn('https://github.com/php/pie');
@@ -201,7 +205,8 @@ final class CommandHelperTest extends TestCase
 
         $repoManager = $this->createMock(RepositoryManager::class);
         $repoManager->method('getRepositories')->willReturn([
-            $composerRepo,
+            $packagistRepo,
+            $privatePackagistRepo,
             $vcsRepo,
             $pathRepo,
         ]);
@@ -214,7 +219,8 @@ final class CommandHelperTest extends TestCase
         self::assertSame(
             <<<'OUTPUT'
             The following repositories are in use for this Target PHP:
-              - Packagist (cannot be removed)
+              - Packagist
+              - Composer (https://repo.packagist.com/example)
               - VCS Repository (https://github.com/php/pie)
               - Path Repository (/path/to/repo)
             OUTPUT,

--- a/test/unit/Command/CommandHelperTest.php
+++ b/test/unit/Command/CommandHelperTest.php
@@ -33,6 +33,7 @@ use Symfony\Component\Console\Output\NullOutput;
 
 use function array_combine;
 use function array_map;
+use function str_replace;
 use function trim;
 
 #[CoversClass(CommandHelper::class)]
@@ -217,14 +218,14 @@ final class CommandHelperTest extends TestCase
         CommandHelper::listRepositories($composer, $output);
 
         self::assertSame(
-            <<<'OUTPUT'
+            str_replace("\r\n", "\n", <<<'OUTPUT'
             The following repositories are in use for this Target PHP:
               - Packagist
               - Composer (https://repo.packagist.com/example)
               - VCS Repository (https://github.com/php/pie)
               - Path Repository (/path/to/repo)
-            OUTPUT,
-            trim($output->fetch()),
+            OUTPUT),
+            str_replace("\r\n", "\n", trim($output->fetch())),
         );
     }
 }

--- a/test/unit/ComposerIntegration/PieJsonEditorTest.php
+++ b/test/unit/ComposerIntegration/PieJsonEditorTest.php
@@ -137,6 +137,58 @@ final class PieJsonEditorTest extends TestCase
         );
     }
 
+    public function testCanAddAndRemoveWithTrailingSlash(): void
+    {
+        $testPieJson = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('pie_json_test_', true) . '.json';
+
+        $editor = new PieJsonEditor($testPieJson);
+        $editor->ensureExists();
+
+        $originalContent = $editor->addRepository(
+            'path',
+            '/pwd/dummy/',
+        );
+
+        self::assertSame(
+            $this->normaliseJson("{\n}\n"),
+            $this->normaliseJson($originalContent),
+        );
+
+        $expectedRepoContent = $this->normaliseJson(<<<'EOF'
+            {
+                "repositories": {
+                    "/pwd/dummy/": {
+                        "type": "path",
+                        "url": "/pwd/dummy/"
+                    }
+                }
+            }
+            EOF);
+
+        self::assertSame(
+            $expectedRepoContent,
+            $this->normaliseJson(file_get_contents($testPieJson)),
+        );
+
+        $originalContent2 = $editor->removeRepository('/pwd/dummy/');
+        self::assertSame(
+            $expectedRepoContent,
+            $this->normaliseJson($originalContent2),
+        );
+
+        $noRepositoriesContent = $this->normaliseJson(<<<'EOF'
+            {
+                "repositories": {
+                }
+            }
+            EOF);
+
+        self::assertSame(
+            $noRepositoriesContent,
+            $this->normaliseJson(file_get_contents($testPieJson)),
+        );
+    }
+
     private function normaliseJson(string $fileContent): string
     {
         return json_encode(json_decode($fileContent));

--- a/test/unit/ComposerIntegration/PieJsonEditorTest.php
+++ b/test/unit/ComposerIntegration/PieJsonEditorTest.php
@@ -157,7 +157,7 @@ final class PieJsonEditorTest extends TestCase
         $expectedRepoContent = $this->normaliseJson(<<<'EOF'
             {
                 "repositories": {
-                    "/pwd/dummy/": {
+                    "/pwd/dummy": {
                         "type": "path",
                         "url": "/pwd/dummy/"
                     }

--- a/test/unit/ComposerIntegration/PieJsonEditorTest.php
+++ b/test/unit/ComposerIntegration/PieJsonEditorTest.php
@@ -61,7 +61,7 @@ final class PieJsonEditorTest extends TestCase
         self::assertSame($originalContent, file_get_contents($testPieJson));
     }
 
-    public function testCanAddRepostiory(): void
+    public function testCanAddAndRemoveRepositories(): void
     {
         $testPieJson = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('pie_json_test_', true) . '.json';
 
@@ -69,21 +69,32 @@ final class PieJsonEditorTest extends TestCase
         $editor->ensureExists();
 
         $originalContent = $editor->addRepository(
-            'myrepo',
             'vcs',
             'https://github.com/php/pie',
         );
 
         self::assertSame("{\n}\n", $originalContent);
 
+        $expectedRepoContent = <<<'EOF'
+            {
+                "repositories": {
+                    "https://github.com/php/pie": {
+                        "type": "vcs",
+                        "url": "https://github.com/php/pie"
+                    }
+                }
+            }
+            EOF;
+
+        self::assertSame($expectedRepoContent, trim(file_get_contents($testPieJson)));
+
+        $originalContent2 = $editor->removeRepository('https://github.com/php/pie');
+        self::assertSame($expectedRepoContent, trim($originalContent2));
+
         self::assertSame(
             <<<'EOF'
             {
                 "repositories": {
-                    "myrepo": {
-                        "type": "vcs",
-                        "url": "https://github.com/php/pie"
-                    }
                 }
             }
             EOF,

--- a/test/unit/ComposerIntegration/PieJsonEditorTest.php
+++ b/test/unit/ComposerIntegration/PieJsonEditorTest.php
@@ -8,6 +8,7 @@ use Php\Pie\ComposerIntegration\PieJsonEditor;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
+use function dirname;
 use function file_get_contents;
 use function json_decode;
 use function json_encode;
@@ -25,7 +26,7 @@ final class PieJsonEditorTest extends TestCase
 
         self::assertFileDoesNotExist($testPieJson);
 
-        (new PieJsonEditor($testPieJson))->ensureExists();
+        (new PieJsonEditor($testPieJson, dirname($testPieJson)))->ensureExists();
 
         self::assertFileExists($testPieJson);
         self::assertSame(
@@ -38,7 +39,7 @@ final class PieJsonEditorTest extends TestCase
     {
         $testPieJson = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('pie_json_test_', true) . '.json';
 
-        $editor = new PieJsonEditor($testPieJson);
+        $editor = new PieJsonEditor($testPieJson, dirname($testPieJson));
         $editor->ensureExists();
 
         $editor->addRequire('foo/bar', '^1.2');
@@ -58,7 +59,7 @@ final class PieJsonEditorTest extends TestCase
     {
         $testPieJson = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('pie_json_test_', true) . '.json';
 
-        $editor = new PieJsonEditor($testPieJson);
+        $editor = new PieJsonEditor($testPieJson, dirname($testPieJson));
         $editor->ensureExists();
         $originalContent = $editor->addRequire('foo/bar', '^1.2');
         $editor->revert($originalContent);
@@ -72,7 +73,7 @@ final class PieJsonEditorTest extends TestCase
     {
         $testPieJson = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('pie_json_test_', true) . '.json';
 
-        $editor = new PieJsonEditor($testPieJson);
+        $editor = new PieJsonEditor($testPieJson, dirname($testPieJson));
         $editor->ensureExists();
 
         $originalContent = $editor->addRepository(
@@ -141,7 +142,7 @@ final class PieJsonEditorTest extends TestCase
     {
         $testPieJson = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('pie_json_test_', true) . '.json';
 
-        $editor = new PieJsonEditor($testPieJson);
+        $editor = new PieJsonEditor($testPieJson, dirname($testPieJson));
         $editor->ensureExists();
 
         $originalContent = $editor->addRepository(

--- a/test/unit/ComposerIntegration/PieJsonEditorTest.php
+++ b/test/unit/ComposerIntegration/PieJsonEditorTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\PieUnitTest\ComposerIntegration;
+
+use Php\Pie\ComposerIntegration\PieJsonEditor;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function file_get_contents;
+use function sys_get_temp_dir;
+use function trim;
+use function uniqid;
+
+use const DIRECTORY_SEPARATOR;
+
+#[CoversClass(PieJsonEditor::class)]
+final class PieJsonEditorTest extends TestCase
+{
+    public function testCreatingPieJson(): void
+    {
+        $testPieJson = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('pie_json_test_', true) . '.json';
+
+        self::assertFileDoesNotExist($testPieJson);
+
+        (new PieJsonEditor($testPieJson))->ensureExists();
+
+        self::assertFileExists($testPieJson);
+        self::assertSame("{\n}\n", file_get_contents($testPieJson));
+    }
+
+    public function testCanAddRequire(): void
+    {
+        $testPieJson = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('pie_json_test_', true) . '.json';
+
+        $editor = new PieJsonEditor($testPieJson);
+        $editor->ensureExists();
+
+        $editor->addRequire('foo/bar', '^1.2');
+        self::assertSame(
+            <<<'EOF'
+{
+    "require": {
+        "foo/bar": "^1.2"
+    }
+}
+EOF,
+            trim(file_get_contents($testPieJson)),
+        );
+    }
+
+    public function testCanRevert(): void
+    {
+        $testPieJson = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('pie_json_test_', true) . '.json';
+
+        $editor = new PieJsonEditor($testPieJson);
+        $editor->ensureExists();
+        $originalContent = $editor->addRequire('foo/bar', '^1.2');
+        $editor->revert($originalContent);
+        self::assertSame($originalContent, file_get_contents($testPieJson));
+    }
+}

--- a/test/unit/ComposerIntegration/PieJsonEditorTest.php
+++ b/test/unit/ComposerIntegration/PieJsonEditorTest.php
@@ -107,10 +107,29 @@ final class PieJsonEditorTest extends TestCase
             $this->normaliseJson($originalContent2),
         );
 
+        $noRepositoriesContent = $this->normaliseJson(<<<'EOF'
+            {
+                "repositories": {
+                }
+            }
+            EOF);
+
+        self::assertSame(
+            $noRepositoriesContent,
+            $this->normaliseJson(file_get_contents($testPieJson)),
+        );
+
+        $originalContent3 = $editor->excludePackagistOrg();
+        self::assertSame(
+            $noRepositoriesContent,
+            $this->normaliseJson($originalContent3),
+        );
+
         self::assertSame(
             $this->normaliseJson(<<<'EOF'
             {
                 "repositories": {
+                    "packagist.org": false
                 }
             }
             EOF),

--- a/test/unit/ComposerIntegration/PieJsonEditorTest.php
+++ b/test/unit/ComposerIntegration/PieJsonEditorTest.php
@@ -40,12 +40,12 @@ final class PieJsonEditorTest extends TestCase
         $editor->addRequire('foo/bar', '^1.2');
         self::assertSame(
             <<<'EOF'
-{
-    "require": {
-        "foo/bar": "^1.2"
-    }
-}
-EOF,
+            {
+                "require": {
+                    "foo/bar": "^1.2"
+                }
+            }
+            EOF,
             trim(file_get_contents($testPieJson)),
         );
     }
@@ -59,5 +59,35 @@ EOF,
         $originalContent = $editor->addRequire('foo/bar', '^1.2');
         $editor->revert($originalContent);
         self::assertSame($originalContent, file_get_contents($testPieJson));
+    }
+
+    public function testCanAddRepostiory(): void
+    {
+        $testPieJson = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('pie_json_test_', true) . '.json';
+
+        $editor = new PieJsonEditor($testPieJson);
+        $editor->ensureExists();
+
+        $originalContent = $editor->addRepository(
+            'myrepo',
+            'vcs',
+            'https://github.com/php/pie',
+        );
+
+        self::assertSame("{\n}\n", $originalContent);
+
+        self::assertSame(
+            <<<'EOF'
+            {
+                "repositories": {
+                    "myrepo": {
+                        "type": "vcs",
+                        "url": "https://github.com/php/pie"
+                    }
+                }
+            }
+            EOF,
+            trim(file_get_contents($testPieJson)),
+        );
     }
 }


### PR DESCRIPTION
 * Fixes #79 
 * Fixes #175 

Allows the use of non-Packagist type repos, such as local paths, VCS repos, Private Packagist, etc.