### PR TITLE
Remove `php-standard-library/psalm-plugin`

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -32,7 +32,7 @@ jobs:
       # temporarily remove Psalm until ready for PHP 8.4
       - name: remove psalm
         if: matrix.php-versions == '8.4'
-        run: composer remove --dev --no-install vimeo/psalm psalm/plugin-phpunit php-standard-library/psalm-plugin
+        run: composer remove --dev --no-install vimeo/psalm psalm/plugin-phpunit
       - uses: ramsey/composer-install@v3
       - name: Run PHPUnit on Windows
         if: matrix.operating-system == 'windows-latest'
@@ -69,7 +69,7 @@ jobs:
       # temporarily remove Psalm until ready for PHP 8.4
       - name: remove psalm
         if: matrix.php-versions == '8.4'
-        run: composer remove --dev --no-install vimeo/psalm psalm/plugin-phpunit php-standard-library/psalm-plugin
+        run: composer remove --dev --no-install vimeo/psalm psalm/plugin-phpunit
       - uses: ramsey/composer-install@v3
       - name: Run Behat on Windows
         if: matrix.operating-system == 'windows-latest'

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,6 @@
     "require-dev": {
         "behat/behat": "^3.17",
         "doctrine/coding-standard": "^12.0",
-        "php-standard-library/psalm-plugin": "^2.3",
         "phpunit/phpunit": "^10.5.39",
         "psalm/plugin-phpunit": "^0.19.0",
         "vimeo/psalm": "^5.26.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d71a5173586deb071e3d24d7c761e9c2",
+    "content-hash": "3e5b020be2a72ed28762d64d89b63795",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -3206,60 +3206,6 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
-        },
-        {
-            "name": "php-standard-library/psalm-plugin",
-            "version": "2.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-standard-library/psalm-plugin.git",
-                "reference": "bf6d560ae498966150bc66a42e02744b0ee242c5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-standard-library/psalm-plugin/zipball/bf6d560ae498966150bc66a42e02744b0ee242c5",
-                "reference": "bf6d560ae498966150bc66a42e02744b0ee242c5",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8.1",
-                "vimeo/psalm": ">=5.16"
-            },
-            "conflict": {
-                "azjezz/psl": "<2.0"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.18",
-                "roave/security-advisories": "dev-master",
-                "squizlabs/php_codesniffer": "^3.5"
-            },
-            "type": "psalm-plugin",
-            "extra": {
-                "psalm": {
-                    "pluginClass": "Psl\\Psalm\\Plugin"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psl\\Psalm\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "azjezz",
-                    "email": "azjezz@protonmail.com"
-                }
-            ],
-            "description": "Psalm plugin for the PHP Standard Library",
-            "support": {
-                "issues": "https://github.com/php-standard-library/psalm-plugin/issues",
-                "source": "https://github.com/php-standard-library/psalm-plugin/tree/2.3.0"
-            },
-            "time": "2023-11-28T12:22:48+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -20,7 +20,6 @@
     </projectFiles>
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
-        <pluginClass class="Psl\Psalm\Plugin"/>
     </plugins>
     <issueHandlers>
         <PossiblyUnusedMethod>


### PR DESCRIPTION
The `azjezz/psl` dependency was removed in php/pie#42, making this dependency obsolete.