### PR TITLE
Allow old PEAR/PECL named convention packages for pre-packaged source

### DIFF
--- a/src/Platform/PrePackagedSourceAssetName.php
+++ b/src/Platform/PrePackagedSourceAssetName.php
@@ -21,6 +21,7 @@ final class PrePackagedSourceAssetName
     public static function packageNames(Package $package): array
     {
         return [
+            // Ideal format for new PIE packages
             strtolower(sprintf(
                 'php_%s-%s-src.tgz',
                 $package->extensionName()->name(),
@@ -28,6 +29,12 @@ final class PrePackagedSourceAssetName
             )),
             strtolower(sprintf(
                 'php_%s-%s-src.zip',
+                $package->extensionName()->name(),
+                $package->version(),
+            )),
+            // Old PEAR/PECL convention
+            strtolower(sprintf(
+                '%s-%s.tgz',
                 $package->extensionName()->name(),
                 $package->version(),
             )),

--- a/test/unit/Downloading/DownloadUrlMethodTest.php
+++ b/test/unit/Downloading/DownloadUrlMethodTest.php
@@ -90,6 +90,7 @@ final class DownloadUrlMethodTest extends TestCase
             [
                 'php_bar-1.2.3-src.tgz',
                 'php_bar-1.2.3-src.zip',
+                'bar-1.2.3.tgz',
             ],
             $downloadUrlMethod->possibleAssetNames($package, $targetPlatform),
         );

--- a/test/unit/Platform/PrePackagedSourceAssetNameTest.php
+++ b/test/unit/Platform/PrePackagedSourceAssetNameTest.php
@@ -21,6 +21,7 @@ final class PrePackagedSourceAssetNameTest extends TestCase
             [
                 'php_foobar-1.2.3-src.tgz',
                 'php_foobar-1.2.3-src.zip',
+                'foobar-1.2.3.tgz',
             ],
             PrePackagedSourceAssetName::packageNames(
                 new Package(


### PR DESCRIPTION
Follow-up for #39

This allows older mongodb pre-packaged archives to be used without modification :100: and also means `pecl package` won't complain :grin: 

```
sudo pecl install php_mongodb-1.21.0dev-src.tgz
parsePackageName(): only one version/state delimiter "-" is allowed in "php_mongodb-1.21.0dev-src.tgz"
invalid package name/package file "php_mongodb-1.21.0dev-src.tgz"
install failed
```