### PR TITLE
composer-json-php-ext-schema.json: update `$id` to correct path

### DIFF
--- a/resources/composer-json-php-ext-schema.json
+++ b/resources/composer-json-php-ext-schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://raw.githubusercontent.com/php/pie/main/composer-json-php-ext-schema.json",
+    "$id": "https://raw.githubusercontent.com/php/pie/main/resources/composer-json-php-ext-schema.json",
     "title": "composer.json php-ext schema",
     "description": "Schema for the proposed php-ext section in composer.json that the new PECL will use to build packages",
     "type": "object",


### PR DESCRIPTION
Ensure that the URI given leads to the actual file rather than a 404 by fixing the end from `main/composer-json-php-ext-schema.json` to `main/resources/composer-json-php-ext-schema.json` since the file is located in the `resources` directory.