### PR TITLE
Added PIE version banner to all commands

### DIFF
--- a/bin/pie
+++ b/bin/pie
@@ -25,7 +25,10 @@ include $_composer_autoload_path ?? __DIR__ . '/../vendor/autoload.php';
 
 $container = Container::factory();
 
-$application = new Application('🥧 PHP Installer for Extensions (PIE)', PieVersion::get());
+$pieAppName = '🥧 PHP Installer for Extensions (PIE)';
+$pieVersion = PieVersion::get();
+$application = new Application($pieAppName, $pieVersion);
+echo $pieAppName . ', ' . $pieVersion . ", from The PHP Foundation\n";
 
 $application->setCommandLoader(new ContainerCommandLoader(
     $container,


### PR DESCRIPTION
Adds a version banner to all commands, e.g.:

```
$ bin/pie install asgrim/example-pie-extension
🥧 PHP Installer for Extensions (PIE), dev-main, from The PHP Foundation
This command may need elevated privileges, and may prompt you for your password.
You are running PHP 8.3.17
Target PHP installation: 8.3.17 nts, on Linux/OSX/etc x86_64 (from /usr/bin/php8.3)
Found package: asgrim/example-pie-extension:2.0.2 which provides ext-example_pie_extension
```