### PR TITLE
Add "pie install" to install missing extensions for a PHP project

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,36 @@ You must now add "extension=example_pie_extension" to your php.ini
 $
 ```
 
+## Installing all extensions for a project
+
+When in your PHP project, you can install any missing top-level extensions:
+
+```
+$ pie install
+🥧 PHP Installer for Extensions (PIE), 0.9.0, from The PHP Foundation
+You are running PHP 8.3.19
+Target PHP installation: 8.3.19 nts, on Linux/OSX/etc x86_64 (from /usr/bin/php8.3)
+Checking extensions for your project your-vendor/your-project
+requires: curl ✅ Already installed
+requires: intl ✅ Already installed
+requires: json ✅ Already installed
+requires: example_pie_extension ⚠️  Missing
+
+The following packages may be suitable, which would you like to install:
+  [0] None
+  [1] asgrim/example-pie-extension: Example PIE extension
+ > 1
+   > 🥧 PHP Installer for Extensions (PIE), 0.9.0, from The PHP Foundation
+   > This command may need elevated privileges, and may prompt you for your password.
+   > You are running PHP 8.3.19
+   > Target PHP installation: 8.3.19 nts, on Linux/OSX/etc x86_64 (from /usr/bin/php8.3)
+   > Found package: asgrim/example-pie-extension:2.0.2 which provides ext-example_pie_extension
+   ... (snip) ...
+   > ✅ Extension is enabled and loaded in /usr/bin/php8.3
+
+Finished checking extensions.
+```
+
 ## More documentation...
 
 The full documentation for PIE can be found in [usage](./docs/usage.md) docs.

--- a/bin/pie
+++ b/bin/pie
@@ -6,6 +6,7 @@ declare(strict_types=1);
 namespace Php\Pie;
 
 use Php\Pie\Command\BuildCommand;
+use Php\Pie\Command\InstallExtensionsForProjectCommand;
 use Php\Pie\Command\DownloadCommand;
 use Php\Pie\Command\InfoCommand;
 use Php\Pie\Command\InstallCommand;
@@ -44,6 +45,7 @@ $application->setCommandLoader(new ContainerCommandLoader(
         'repository:remove' => RepositoryRemoveCommand::class,
         'uninstall' => UninstallCommand::class,
         'self-update' => SelfUpdateCommand::class,
+        'install-extensions-for-project' => InstallExtensionsForProjectCommand::class,
     ]
 ));
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -258,6 +258,39 @@ You can list the repositories for the target PHP installation with:
 
 * `pie repository:list [--with-php-config=...]`
 
+## Check and install missing extensions for your project
+
+You can use `pie install` when in a PHP project working directory to check the
+extensions the project requires are present. If an extension is missing, PIE
+will try to find an installation candidate and interactively ask if you would
+like to install one. For example:
+
+```
+$ pie install
+🥧 PHP Installer for Extensions (PIE), 0.9.0, from The PHP Foundation
+You are running PHP 8.3.19
+Target PHP installation: 8.3.19 nts, on Linux/OSX/etc x86_64 (from /usr/bin/php8.3)
+Checking extensions for your project your-vendor/your-project
+requires: curl ✅ Already installed
+requires: intl ✅ Already installed
+requires: json ✅ Already installed
+requires: example_pie_extension ⚠️  Missing
+
+The following packages may be suitable, which would you like to install:
+  [0] None
+  [1] asgrim/example-pie-extension: Example PIE extension
+ > 1
+   > 🥧 PHP Installer for Extensions (PIE), 0.9.0, from The PHP Foundation
+   > This command may need elevated privileges, and may prompt you for your password.
+   > You are running PHP 8.3.19
+   > Target PHP installation: 8.3.19 nts, on Linux/OSX/etc x86_64 (from /usr/bin/php8.3)
+   > Found package: asgrim/example-pie-extension:2.0.2 which provides ext-example_pie_extension
+   ... (snip) ...
+   > ✅ Extension is enabled and loaded in /usr/bin/php8.3
+
+Finished checking extensions.
+```
+
 ## Comparison with PECL
 
 Since PIE is a replacement for PECL, here is a comparison of the commands that

--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -38,13 +38,13 @@ use const PHP_VERSION;
 /** @internal This is not public API for PIE, so should not be depended upon unless you accept the risk of BC breaks */
 final class CommandHelper
 {
-    private const ARG_REQUESTED_PACKAGE_AND_VERSION = 'requested-package-and-version';
-    public const OPTION_WITH_PHP_CONFIG             = 'with-php-config';
-    public const OPTION_WITH_PHP_PATH               = 'with-php-path';
-    public const OPTION_WITH_PHPIZE_PATH            = 'with-phpize-path';
-    private const OPTION_MAKE_PARALLEL_JOBS         = 'make-parallel-jobs';
-    private const OPTION_SKIP_ENABLE_EXTENSION      = 'skip-enable-extension';
-    private const OPTION_FORCE                      = 'force';
+    public const ARG_REQUESTED_PACKAGE_AND_VERSION = 'requested-package-and-version';
+    public const OPTION_WITH_PHP_CONFIG            = 'with-php-config';
+    public const OPTION_WITH_PHP_PATH              = 'with-php-path';
+    public const OPTION_WITH_PHPIZE_PATH           = 'with-phpize-path';
+    private const OPTION_MAKE_PARALLEL_JOBS        = 'make-parallel-jobs';
+    private const OPTION_SKIP_ENABLE_EXTENSION     = 'skip-enable-extension';
+    private const OPTION_FORCE                     = 'force';
 
     /** @psalm-suppress UnusedConstructor */
     private function __construct()
@@ -77,7 +77,7 @@ final class CommandHelper
     {
         $command->addArgument(
             self::ARG_REQUESTED_PACKAGE_AND_VERSION,
-            InputArgument::REQUIRED,
+            InputArgument::OPTIONAL,
             'The PIE package name and version constraint to use, in the format {vendor/package}{?:{?version-constraint}{?@stability}}, for example `xdebug/xdebug:^3.4@alpha`, `xdebug/xdebug:@alpha`, `xdebug/xdebug:^3.4`, etc.',
         );
         $command->addOption(

--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -39,9 +39,9 @@ use const PHP_VERSION;
 final class CommandHelper
 {
     private const ARG_REQUESTED_PACKAGE_AND_VERSION = 'requested-package-and-version';
-    private const OPTION_WITH_PHP_CONFIG            = 'with-php-config';
-    private const OPTION_WITH_PHP_PATH              = 'with-php-path';
-    private const OPTION_WITH_PHPIZE_PATH           = 'with-phpize-path';
+    public const OPTION_WITH_PHP_CONFIG             = 'with-php-config';
+    public const OPTION_WITH_PHP_PATH               = 'with-php-path';
+    public const OPTION_WITH_PHPIZE_PATH            = 'with-phpize-path';
     private const OPTION_MAKE_PARALLEL_JOBS         = 'make-parallel-jobs';
     private const OPTION_SKIP_ENABLE_EXTENSION      = 'skip-enable-extension';
     private const OPTION_FORCE                      = 'force';

--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -14,9 +14,17 @@ use Php\Pie\Platform\TargetPlatform;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Webmozart\Assert\Assert;
 
+use function array_combine;
+use function array_filter;
+use function array_keys;
+use function array_map;
+use function array_merge;
+use function array_values;
 use function sprintf;
 
 #[AsCommand(
@@ -40,8 +48,29 @@ final class InstallCommand extends Command
         CommandHelper::configureDownloadBuildInstallOptions($this);
     }
 
+    private function invokeInstallForProject(InputInterface $input, OutputInterface $output): int
+    {
+        $originalSuppliedOptions = array_filter($input->getOptions());
+        $installForProjectInput  = new ArrayInput(array_merge(
+            ['command' => 'install-extensions-for-project'],
+            array_combine(
+                array_map(static fn ($key) => '--' . $key, array_keys($originalSuppliedOptions)),
+                array_values($originalSuppliedOptions),
+            ),
+        ));
+
+        $application = $this->getApplication();
+        Assert::notNull($application);
+
+        return $application->doRun($installForProjectInput, $output);
+    }
+
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        if (! $input->getArgument(CommandHelper::ARG_REQUESTED_PACKAGE_AND_VERSION)) {
+            return $this->invokeInstallForProject($input, $output);
+        }
+
         if (! TargetPlatform::isRunningAsRoot()) {
             $output->writeln('This command may need elevated privileges, and may prompt you for your password.');
         }

--- a/src/Command/InstallExtensionsForProjectCommand.php
+++ b/src/Command/InstallExtensionsForProjectCommand.php
@@ -4,10 +4,7 @@ declare(strict_types=1);
 
 namespace Php\Pie\Command;
 
-use Composer\Factory as ComposerFactory;
-use Composer\IO\ConsoleIO;
 use Composer\Package\Link;
-use Composer\Package\RootPackageInterface;
 use OutOfRangeException;
 use Php\Pie\ComposerIntegration\PieComposerFactory;
 use Php\Pie\ComposerIntegration\PieComposerRequest;
@@ -19,7 +16,6 @@ use Php\Pie\Installing\InstallForPhpProject\InstallSelectedPackage;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
@@ -27,7 +23,6 @@ use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Throwable;
-use Webmozart\Assert\Assert;
 
 use function array_filter;
 use function array_keys;

--- a/src/Command/InstallExtensionsForProjectCommand.php
+++ b/src/Command/InstallExtensionsForProjectCommand.php
@@ -145,11 +145,18 @@ final class InstallExtensionsForProjectCommand extends Command
                 } catch (OutOfRangeException) {
                     $anyErrorsHappened = true;
 
-                    assert($output instanceof ConsoleOutputInterface);
-                    $output->getErrorOutput()->writeln(sprintf(
+                    $message = sprintf(
                         '<error>No packages were found for %s</error>',
                         $extension->nameWithExtPrefix(),
-                    ));
+                    );
+
+                    if ($output instanceof ConsoleOutputInterface) {
+                        $output->getErrorOutput()->writeln($message);
+
+                        return;
+                    }
+
+                    $output->writeln($message);
 
                     return;
                 }
@@ -185,10 +192,15 @@ final class InstallExtensionsForProjectCommand extends Command
                 } catch (Throwable $t) {
                     $anyErrorsHappened = true;
 
-                    assert($output instanceof ConsoleOutputInterface);
-                    $output->getErrorOutput()->writeln('<error>' . $t->getMessage() . '</error>');
+                    $message = '<error>' . $t->getMessage() . '</error>';
 
-                    return;
+                    if ($output instanceof ConsoleOutputInterface) {
+                        $output->getErrorOutput()->writeln($message);
+
+                        return;
+                    }
+
+                    $output->writeln($message);
                 }
             },
         );

--- a/src/Command/InstallExtensionsForProjectCommand.php
+++ b/src/Command/InstallExtensionsForProjectCommand.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\Pie\Command;
+
+use Composer\Factory as ComposerFactory;
+use Composer\IO\ConsoleIO;
+use Composer\Package\Link;
+use Composer\Package\RootPackageInterface;
+use OutOfRangeException;
+use Php\Pie\ComposerIntegration\PieComposerFactory;
+use Php\Pie\ComposerIntegration\PieComposerRequest;
+use Php\Pie\ExtensionName;
+use Php\Pie\ExtensionType;
+use Php\Pie\Installing\InstallForPhpProject\FindMatchingPackages;
+use Php\Pie\Installing\InstallForPhpProject\InstallSelectedPackage;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Throwable;
+use Webmozart\Assert\Assert;
+
+use function array_filter;
+use function array_keys;
+use function array_map;
+use function array_merge;
+use function array_walk;
+use function assert;
+use function getcwd;
+use function in_array;
+use function sprintf;
+use function str_starts_with;
+use function strlen;
+use function strpos;
+use function substr;
+
+use const PHP_EOL;
+
+#[AsCommand(
+    name: 'install-extensions-for-project',
+    description: 'Check a project for its extension dependencies, and offers to install them',
+)]
+final class InstallExtensionsForProjectCommand extends Command
+{
+    public function __construct(
+        private readonly FindMatchingPackages $findMatchingPackages,
+        private readonly InstallSelectedPackage $installSelectedPackage,
+        private readonly ContainerInterface $container,
+    ) {
+        parent::__construct();
+    }
+
+    public function configure(): void
+    {
+        parent::configure();
+
+        CommandHelper::configurePhpConfigOptions($this);
+    }
+
+    private function rootPackageForCwd(InputInterface $input, OutputInterface $output): RootPackageInterface
+    {
+        $io = new ConsoleIO($input, $output, new HelperSet([]));
+
+        return ComposerFactory::create($io)->getPackage();
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $helper = $this->getHelper('question');
+        assert($helper instanceof QuestionHelper);
+
+        Assert::isInstanceOf($output, ConsoleOutputInterface::class);
+
+        $targetPlatform = CommandHelper::determineTargetPlatformFromInputs($input, $output);
+
+        $rootPackage = $this->rootPackageForCwd($input, $output);
+
+        if (ExtensionType::isValid($rootPackage->getType())) {
+            $output->writeln('<error>This composer.json is for an extension, installing missing packages is not supported.</error>');
+
+            return Command::INVALID;
+        }
+
+        $output->writeln(sprintf(
+            'Checking extensions for your project <info>%s</info> (path: %s)',
+            $rootPackage->getPrettyName(),
+            getcwd(),
+        ));
+
+        $rootPackageExtensionsRequired = array_filter(
+            array_merge($rootPackage->getRequires(), $rootPackage->getDevRequires()),
+            static function (Link $link) {
+                $linkTarget = $link->getTarget();
+                if (! str_starts_with($linkTarget, 'ext-')) {
+                    return false;
+                }
+
+                return ExtensionName::isValidExtensionName(substr($linkTarget, strlen('ext-')));
+            },
+        );
+
+        $pieComposer = PieComposerFactory::createPieComposer(
+            $this->container,
+            PieComposerRequest::noOperation(
+                new NullOutput(),
+                $targetPlatform,
+            ),
+        );
+
+        $phpEnabledExtensions = array_keys($targetPlatform->phpBinaryPath->extensions());
+
+        $anyErrorsHappened = false;
+
+        array_walk(
+            $rootPackageExtensionsRequired,
+            function (Link $link) use ($pieComposer, $phpEnabledExtensions, $input, $output, $helper, &$anyErrorsHappened): void {
+                $extension = ExtensionName::normaliseFromString($link->getTarget());
+
+                if (in_array($extension->name(), $phpEnabledExtensions)) {
+                    $output->writeln(sprintf(
+                        '%s: <info>%s</info> ✅ Already installed',
+                        $link->getDescription(),
+                        $extension->name(),
+                    ));
+
+                    return;
+                }
+
+                $output->writeln(sprintf(
+                    '%s: <comment>%s</comment> ⚠️  Missing',
+                    $link->getDescription(),
+                    $extension->name(),
+                ));
+
+                try {
+                    $matches = $this->findMatchingPackages->for($pieComposer, $extension);
+                } catch (OutOfRangeException) {
+                    $anyErrorsHappened = true;
+
+                    assert($output instanceof ConsoleOutputInterface);
+                    $output->getErrorOutput()->writeln(sprintf(
+                        '<error>No packages were found for %s</error>',
+                        $extension->nameWithExtPrefix(),
+                    ));
+
+                    return;
+                }
+
+                $choiceQuestion = new ChoiceQuestion(
+                    "\nThe following packages may be suitable, which would you like to install: ",
+                    array_merge(
+                        ['None'],
+                        array_map(
+                            static function (array $match): string {
+                                return sprintf('%s: %s', $match['name'], $match['description'] ?? 'no description available');
+                            },
+                            $matches,
+                        ),
+                    ),
+                    0,
+                );
+
+                $selectedPackageAnswer = (string) $helper->ask($input, $output, $choiceQuestion);
+
+                if ($selectedPackageAnswer === 'None') {
+                    $output->writeln('Okay I won\'t install anything for ' . $extension->name());
+
+                    return;
+                }
+
+                try {
+                    $this->installSelectedPackage->withPieCli(
+                        substr($selectedPackageAnswer, 0, (int) strpos($selectedPackageAnswer, ':')),
+                        $input,
+                        $output,
+                    );
+                } catch (Throwable $t) {
+                    $anyErrorsHappened = true;
+
+                    assert($output instanceof ConsoleOutputInterface);
+                    $output->getErrorOutput()->writeln('<error>' . $t->getMessage() . '</error>');
+
+                    return;
+                }
+            },
+        );
+
+        $output->writeln(PHP_EOL . 'Finished checking extensions.');
+
+        /**
+         * @psalm-suppress TypeDoesNotContainType
+         * @psalm-suppress RedundantCondition
+         */
+        return $anyErrorsHappened ? self::FAILURE : self::SUCCESS;
+    }
+}

--- a/src/Container.php
+++ b/src/Container.php
@@ -13,6 +13,7 @@ use Php\Pie\Command\BuildCommand;
 use Php\Pie\Command\DownloadCommand;
 use Php\Pie\Command\InfoCommand;
 use Php\Pie\Command\InstallCommand;
+use Php\Pie\Command\InstallExtensionsForProjectCommand;
 use Php\Pie\Command\RepositoryAddCommand;
 use Php\Pie\Command\RepositoryListCommand;
 use Php\Pie\Command\RepositoryRemoveCommand;
@@ -58,6 +59,7 @@ final class Container
         $container->singleton(RepositoryRemoveCommand::class);
         $container->singleton(UninstallCommand::class);
         $container->singleton(SelfUpdateCommand::class);
+        $container->singleton(InstallExtensionsForProjectCommand::class);
 
         $container->singleton(QuieterConsoleIO::class, static function (ContainerInterface $container): QuieterConsoleIO {
             return new QuieterConsoleIO(

--- a/src/Installing/InstallForPhpProject/FindMatchingPackages.php
+++ b/src/Installing/InstallForPhpProject/FindMatchingPackages.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\Pie\Installing\InstallForPhpProject;
+
+use Composer\Composer;
+use Composer\Repository\RepositoryInterface;
+use OutOfRangeException;
+use Php\Pie\ExtensionName;
+
+use function array_merge;
+use function count;
+use function usort;
+
+/**
+ * @internal This is not public API for PIE, so should not be depended upon unless you accept the risk of BC breaks
+ *
+ * @psalm-type MatchingPackages = list<array{name: string, description: ?string, ...}>
+ */
+class FindMatchingPackages
+{
+    /** @return MatchingPackages */
+    public function for(Composer $pieComposer, ExtensionName $extension): array
+    {
+        $matches = [];
+        foreach ($pieComposer->getRepositoryManager()->getRepositories() as $repo) {
+            $matches = array_merge($matches, $repo->search($extension->name(), RepositoryInterface::SEARCH_FULLTEXT, 'php-ext'));
+            $matches = array_merge($matches, $repo->search($extension->name(), RepositoryInterface::SEARCH_FULLTEXT, 'php-ext-zend'));
+        }
+
+        if (! count($matches)) {
+            throw new OutOfRangeException('No matches found for ' . $extension->name());
+        }
+
+        usort($matches, static function (array $a, array $b): int {
+            return $b['downloads'] <=> $a['downloads'];
+        });
+
+        return $matches;
+    }
+}

--- a/src/Installing/InstallForPhpProject/FindRootPackage.php
+++ b/src/Installing/InstallForPhpProject/FindRootPackage.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\Pie\Installing\InstallForPhpProject;
+
+use Composer\Factory as ComposerFactory;
+use Composer\IO\ConsoleIO;
+use Composer\Package\RootPackageInterface;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class FindRootPackage
+{
+    public function forCwd(InputInterface $input, OutputInterface $output): RootPackageInterface
+    {
+        $io = new ConsoleIO($input, $output, new HelperSet([]));
+
+        return ComposerFactory::create($io)->getPackage();
+    }
+}

--- a/src/Installing/InstallForPhpProject/InstallSelectedPackage.php
+++ b/src/Installing/InstallForPhpProject/InstallSelectedPackage.php
@@ -14,7 +14,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 use function array_filter;
 use function array_key_exists;
 use function array_walk;
-use function assert;
 use function getcwd;
 use function in_array;
 use function is_string;
@@ -68,15 +67,13 @@ class InstallSelectedPackage
             getcwd(),
             null,
             static function (string $outOrErr, string $message) use ($output): void {
-                assert($output instanceof ConsoleOutputInterface);
-
-                if ($outOrErr === \Symfony\Component\Process\Process::OUT) {
-                    $output->write('   > ' . $message);
+                if ($output instanceof ConsoleOutputInterface && $outOrErr === \Symfony\Component\Process\Process::ERR) {
+                    $output->getErrorOutput()->write('   > ' . $message);
 
                     return;
                 }
 
-                $output->getErrorOutput()->write('   > ' . $message);
+                $output->write('   > ' . $message);
             },
         );
     }

--- a/src/Installing/InstallForPhpProject/InstallSelectedPackage.php
+++ b/src/Installing/InstallForPhpProject/InstallSelectedPackage.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\Pie\Installing\InstallForPhpProject;
+
+use Php\Pie\Command\CommandHelper;
+use Php\Pie\Util\Process;
+use RuntimeException;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function array_filter;
+use function array_key_exists;
+use function array_walk;
+use function assert;
+use function getcwd;
+use function in_array;
+use function is_string;
+
+use const ARRAY_FILTER_USE_BOTH;
+
+/** @internal This is not public API for PIE, so should not be depended upon unless you accept the risk of BC breaks */
+class InstallSelectedPackage
+{
+    public function withPieCli(string $selectedPackage, InputInterface $input, OutputInterface $output): void
+    {
+        /** @psalm-suppress TypeDoesNotContainType */
+        $self = array_key_exists('PHP_SELF', $_SERVER) && is_string($_SERVER['PHP_SELF']) ? $_SERVER['PHP_SELF'] : '';
+        if ($self === '') {
+            throw new RuntimeException('Could not find PHP_SELF');
+        }
+
+        $process = [
+            $self,
+            'install',
+            $selectedPackage,
+        ];
+
+        $phpPathOptions = array_filter(
+            $input->getOptions(),
+            static function (mixed $value, string|int $key): bool {
+                return $value !== null
+                    && $value !== false
+                    && in_array(
+                        $key,
+                        [
+                            CommandHelper::OPTION_WITH_PHP_CONFIG,
+                            CommandHelper::OPTION_WITH_PHP_PATH,
+                            CommandHelper::OPTION_WITH_PHPIZE_PATH,
+                        ],
+                    );
+            },
+            ARRAY_FILTER_USE_BOTH,
+        );
+
+        array_walk(
+            $phpPathOptions,
+            static function (string $value, string $key) use (&$process): void {
+                $process[] = '--' . $key;
+                $process[] = $value;
+            },
+        );
+
+        Process::run(
+            $process,
+            getcwd(),
+            null,
+            static function (string $outOrErr, string $message) use ($output): void {
+                assert($output instanceof ConsoleOutputInterface);
+
+                if ($outOrErr === \Symfony\Component\Process\Process::OUT) {
+                    $output->write('   > ' . $message);
+
+                    return;
+                }
+
+                $output->getErrorOutput()->write('   > ' . $message);
+            },
+        );
+    }
+}

--- a/test/assets/fake-pie-cli/happy.bat
+++ b/test/assets/fake-pie-cli/happy.bat
@@ -1,0 +1,5 @@
+@echo off
+
+echo Params passed: %*
+
+exit /b 0

--- a/test/assets/fake-pie-cli/happy.sh
+++ b/test/assets/fake-pie-cli/happy.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+echo "Params passed: ${*}"
+exit 0

--- a/test/integration/Command/InstallExtensionsForProjectCommandTest.php
+++ b/test/integration/Command/InstallExtensionsForProjectCommandTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\PieIntegrationTest\Command;
+
+use Composer\Package\Link;
+use Composer\Package\RootPackage;
+use Composer\Semver\Constraint\Constraint;
+use Php\Pie\Command\InstallExtensionsForProjectCommand;
+use Php\Pie\ComposerIntegration\InstallAndBuildProcess;
+use Php\Pie\ComposerIntegration\MinimalHelperSet;
+use Php\Pie\ComposerIntegration\QuieterConsoleIO;
+use Php\Pie\Installing\InstallForPhpProject\FindMatchingPackages;
+use Php\Pie\Installing\InstallForPhpProject\FindRootPackage;
+use Php\Pie\Installing\InstallForPhpProject\InstallSelectedPackage;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[CoversClass(InstallExtensionsForProjectCommand::class)]
+final class InstallExtensionsForProjectCommandTest extends TestCase
+{
+    private CommandTester $commandTester;
+    private FindRootPackage&MockObject $findRootpackage;
+    private FindMatchingPackages&MockObject $findMatchingPackages;
+    private InstallSelectedPackage&MockObject $installSelectedPackage;
+    private QuestionHelper&MockObject $questionHelper;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturnCallback(
+            /** @param class-string $service */
+            function (string $service): mixed {
+                switch ($service) {
+                    case QuieterConsoleIO::class:
+                        return new QuieterConsoleIO(
+                            new ArrayInput([]),
+                            new BufferedOutput(),
+                            new MinimalHelperSet(['question' => new QuestionHelper()]),
+                        );
+
+                    default:
+                        return $this->createMock($service);
+                }
+            },
+        );
+
+        $this->findRootpackage        = $this->createMock(FindRootPackage::class);
+        $this->findMatchingPackages   = $this->createMock(FindMatchingPackages::class);
+        $this->installSelectedPackage = $this->createMock(InstallSelectedPackage::class);
+        $this->questionHelper         = $this->createMock(QuestionHelper::class);
+
+        $cmd = new InstallExtensionsForProjectCommand(
+            $this->findRootpackage,
+            $this->findMatchingPackages,
+            $this->installSelectedPackage,
+            $container,
+        );
+        $cmd->setHelperSet(new HelperSet([
+            'question' => $this->questionHelper,
+        ]));
+        $this->commandTester = new CommandTester($cmd);
+    }
+
+    public function testInstallingExtensionsForProject(): void
+    {
+        $rootPackage = new RootPackage('my/project', '1.2.3.0', '1.2.3');
+        $rootPackage->setRequires([
+            new Link('my/project', 'ext-standard', new Constraint('=', '*'), Link::TYPE_REQUIRE),
+            new Link('my/project', 'ext-foobar', new Constraint('=', '*'), Link::TYPE_REQUIRE),
+        ]);
+        $this->findRootpackage->method('forCwd')->willReturn($rootPackage);
+
+        $this->findMatchingPackages->method('for')->willReturn([
+            ['name' => 'vendor1/foobar', 'description' => 'The official foobar implementation'],
+            ['name' => 'vendor2/afoobar', 'description' => 'An improved async foobar extension'],
+        ]);
+
+        $this->questionHelper->method('ask')->willReturn('vendor1/foobar: The official foobar implementation');
+
+        $this->installSelectedPackage->expects(self::once())
+            ->method('withPieCli')
+            ->with('vendor1/foobar');
+
+        $this->commandTester->execute(
+            [],
+            ['verbosity' => BufferedOutput::VERBOSITY_VERY_VERBOSE],
+        );
+
+        $outputString = $this->commandTester->getDisplay();
+
+        $this->commandTester->assertCommandIsSuccessful();
+        self::assertStringContainsString('Checking extensions for your project my/project', $outputString);
+        self::assertStringContainsString('requires: standard ✅ Already installed', $outputString);
+        self::assertStringContainsString('requires: foobar ⚠️  Missing', $outputString);
+    }
+}

--- a/test/integration/Command/InstallExtensionsForProjectCommandTest.php
+++ b/test/integration/Command/InstallExtensionsForProjectCommandTest.php
@@ -8,7 +8,6 @@ use Composer\Package\Link;
 use Composer\Package\RootPackage;
 use Composer\Semver\Constraint\Constraint;
 use Php\Pie\Command\InstallExtensionsForProjectCommand;
-use Php\Pie\ComposerIntegration\InstallAndBuildProcess;
 use Php\Pie\ComposerIntegration\MinimalHelperSet;
 use Php\Pie\ComposerIntegration\QuieterConsoleIO;
 use Php\Pie\Installing\InstallForPhpProject\FindMatchingPackages;
@@ -76,8 +75,8 @@ final class InstallExtensionsForProjectCommandTest extends TestCase
     {
         $rootPackage = new RootPackage('my/project', '1.2.3.0', '1.2.3');
         $rootPackage->setRequires([
-            new Link('my/project', 'ext-standard', new Constraint('=', '*'), Link::TYPE_REQUIRE),
-            new Link('my/project', 'ext-foobar', new Constraint('=', '*'), Link::TYPE_REQUIRE),
+            'ext-standard' => new Link('my/project', 'ext-standard', new Constraint('=', '*'), Link::TYPE_REQUIRE),
+            'ext-foobar' => new Link('my/project', 'ext-foobar', new Constraint('=', '*'), Link::TYPE_REQUIRE),
         ]);
         $this->findRootpackage->method('forCwd')->willReturn($rootPackage);
 

--- a/test/unit/Installing/InstallForPhpProject/InstallSelectedPackageTest.php
+++ b/test/unit/Installing/InstallForPhpProject/InstallSelectedPackageTest.php
@@ -26,9 +26,7 @@ final class InstallSelectedPackageTest extends TestCase
         $_SERVER['PHP_SELF'] = Platform::isWindows() ? self::FAKE_HAPPY_BAT : self::FAKE_HAPPY_SH;
 
         $input  = new ArrayInput(
-            [
-                '--with-php-config' => '/path/to/php/config',
-            ],
+            ['--with-php-config' => '/path/to/php/config'],
             new InputDefinition([
                 new InputOption('with-php-config', null, InputOption::VALUE_REQUIRED),
             ]),

--- a/test/unit/Installing/InstallForPhpProject/InstallSelectedPackageTest.php
+++ b/test/unit/Installing/InstallForPhpProject/InstallSelectedPackageTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\PieUnitTest\Installing\InstallForPhpProject;
+
+use Composer\Util\Platform;
+use Php\Pie\Installing\InstallForPhpProject\InstallSelectedPackage;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+use function trim;
+
+#[CoversClass(InstallSelectedPackage::class)]
+final class InstallSelectedPackageTest extends TestCase
+{
+    private const FAKE_HAPPY_SH  = __DIR__ . '/../../../assets/fake-pie-cli/happy.sh';
+    private const FAKE_HAPPY_BAT = __DIR__ . '/../../../assets/fake-pie-cli/happy.bat';
+
+    public function testWithPieCli(): void
+    {
+        $_SERVER['PHP_SELF'] = Platform::isWindows() ? self::FAKE_HAPPY_BAT : self::FAKE_HAPPY_SH;
+
+        $input  = new ArrayInput(
+            [
+                '--with-php-config' => '/path/to/php/config',
+            ],
+            new InputDefinition([
+                new InputOption('with-php-config', null, InputOption::VALUE_REQUIRED),
+            ]),
+        );
+        $output = new BufferedOutput();
+
+        (new InstallSelectedPackage())->withPieCli(
+            'foo/bar',
+            $input,
+            $output,
+        );
+
+        self::assertSame('> Params passed: install foo/bar --with-php-config /path/to/php/config', trim($output->fetch()));
+    }
+}


### PR DESCRIPTION
Add `pie install` without parameters to check a PHP project for missing extensions