### PR TITLE
Fix self-update command issues

### DIFF
--- a/box.json.dist
+++ b/box.json.dist
@@ -1,5 +1,9 @@
 {
     "alias": "pie.phar",
     "output": "pie.phar",
-    "git": "pie_version"
+    "git": "pie_version",
+    "force-autodiscovery": true,
+    "directories": [
+        "resources"
+    ]
 }

--- a/src/Downloading/GithubPackageReleaseAssets.php
+++ b/src/Downloading/GithubPackageReleaseAssets.php
@@ -80,7 +80,7 @@ final class GithubPackageReleaseAssets implements PackageReleaseAssets
             $decodedRepsonse = $httpDownloader->get(
                 $this->githubApiBaseUrl . '/repos/' . $package->githubOrgAndRepository() . '/releases/tags/' . $package->version(),
                 [
-                    'retry-auth-failure' => false,
+                    'retry-auth-failure' => true,
                     'http' => [
                         'method' => 'GET',
                         'header' => $authHelper->addAuthenticationHeader([], $this->githubApiBaseUrl, $package->downloadUrl()),

--- a/src/SelfManage/Update/FetchPieReleaseFromGitHub.php
+++ b/src/SelfManage/Update/FetchPieReleaseFromGitHub.php
@@ -37,7 +37,7 @@ final class FetchPieReleaseFromGitHub implements FetchPieRelease
         $decodedRepsonse = $this->httpDownloader->get(
             $url,
             [
-                'retry-auth-failure' => false,
+                'retry-auth-failure' => true,
                 'http' => [
                     'method' => 'GET',
                     'header' => $this->authHelper->addAuthenticationHeader([], $this->githubApiBaseUrl, $url),
@@ -81,7 +81,7 @@ final class FetchPieReleaseFromGitHub implements FetchPieRelease
         $pharContent = $this->httpDownloader->get(
             $releaseMetadata->downloadUrl,
             [
-                'retry-auth-failure' => false,
+                'retry-auth-failure' => true,
                 'http' => [
                     'method' => 'GET',
                     'header' => $this->authHelper->addAuthenticationHeader([], $this->githubApiBaseUrl, $releaseMetadata->downloadUrl),

--- a/src/SelfManage/Verify/FallbackVerificationUsingOpenSsl.php
+++ b/src/SelfManage/Verify/FallbackVerificationUsingOpenSsl.php
@@ -285,7 +285,7 @@ final class FallbackVerificationUsingOpenSsl implements VerifyPiePhar
             $decodedJson = $this->httpDownloader->get(
                 $attestationUrl,
                 [
-                    'retry-auth-failure' => false,
+                    'retry-auth-failure' => true,
                     'http' => [
                         'method' => 'GET',
                         'header' => $this->authHelper->addAuthenticationHeader([], $this->githubApiBaseUrl, $attestationUrl),

--- a/test/unit/SelfManage/Update/FetchPieReleaseFromGitHubTest.php
+++ b/test/unit/SelfManage/Update/FetchPieReleaseFromGitHubTest.php
@@ -36,7 +36,7 @@ final class FetchPieReleaseFromGitHubTest extends TestCase
             ->with(
                 $url,
                 [
-                    'retry-auth-failure' => false,
+                    'retry-auth-failure' => true,
                     'http' => [
                         'method' => 'GET',
                         'header' => ['Authorization: Bearer fake-token'],
@@ -91,7 +91,7 @@ final class FetchPieReleaseFromGitHubTest extends TestCase
             ->with(
                 $url,
                 [
-                    'retry-auth-failure' => false,
+                    'retry-auth-failure' => true,
                     'http' => [
                         'method' => 'GET',
                         'header' => ['Authorization: Bearer fake-token'],

--- a/test/unit/SelfManage/Verify/FallbackVerificationUsingOpenSslTest.php
+++ b/test/unit/SelfManage/Verify/FallbackVerificationUsingOpenSslTest.php
@@ -142,7 +142,7 @@ EOF);
             ->with(
                 $url,
                 [
-                    'retry-auth-failure' => false,
+                    'retry-auth-failure' => true,
                     'http' => [
                         'method' => 'GET',
                         'header' => ['Authorization: Bearer fake-token'],


### PR DESCRIPTION
Fixes #232 

Two issues identified;

 - `retry-auth-failure` should be `true` to allow interactive prompting
 - `resources` path was not being included in compiled PHAR