### PR TITLE
Suppress warning when file's not readable

### DIFF
--- a/src/Installing/Ini/AddExtensionToTheIniFile.php
+++ b/src/Installing/Ini/AddExtensionToTheIniFile.php
@@ -42,7 +42,7 @@ class AddExtensionToTheIniFile
             return false;
         }
 
-        $originalIniContent = file_get_contents($ini);
+        $originalIniContent = @file_get_contents($ini);
 
         if (! is_string($originalIniContent)) {
             $output->writeln(


### PR DESCRIPTION
```
1 test triggered 1 PHP warning:

1) /home/matteo/OSS/pie/src/Installing/Ini/AddExtensionToTheIniFile.php:45
file_get_contents(/tmp/PIE_unreadable_ini_fileCIbpMY): Failed to open stream: Permission denied

Triggered by:

* Php\PieUnitTest\Installing\Ini\AddExtensionToTheIniFileTest::testReturnsFalseWhenExistingIniCouldNotBeRead
  /home/matteo/OSS/pie/test/unit/Installing/Ini/AddExtensionToTheIniFileTest.php:115
```

on my CI, now also running pie tests with the latest nightly PHP versions (except master, currently):

https://github.com/mbeccati/php-latest-builds/actions/runs/15116912401/job/42489797649 