### PR TITLE
Update Composer::AuthHelper usage

### DIFF
--- a/src/Downloading/GithubPackageReleaseAssets.php
+++ b/src/Downloading/GithubPackageReleaseAssets.php
@@ -77,13 +77,14 @@ final class GithubPackageReleaseAssets implements PackageReleaseAssets
         Assert::notNull($package->downloadUrl());
 
         try {
-            $decodedRepsonse = $httpDownloader->get(
+            $authOptions             = $authHelper->addAuthenticationOptions([], $this->githubApiBaseUrl, $package->downloadUrl());
+            $decodedRepsonse         = $httpDownloader->get(
                 $this->githubApiBaseUrl . '/repos/' . $package->githubOrgAndRepository() . '/releases/tags/' . $package->version(),
                 [
                     'retry-auth-failure' => true,
                     'http' => [
                         'method' => 'GET',
-                        'header' => $authHelper->addAuthenticationHeader([], $this->githubApiBaseUrl, $package->downloadUrl()),
+                        'header' => $authOptions['http']['header'],
                     ],
                 ],
             )->decodeJson();

--- a/src/SelfManage/Update/FetchPieReleaseFromGitHub.php
+++ b/src/SelfManage/Update/FetchPieReleaseFromGitHub.php
@@ -34,13 +34,14 @@ final class FetchPieReleaseFromGitHub implements FetchPieRelease
     {
         $url = $this->githubApiBaseUrl . self::PIE_LATEST_RELEASE_URL;
 
-        $decodedRepsonse = $this->httpDownloader->get(
+        $authOptions = $this->authHelper->addAuthenticationOptions([], $this->githubApiBaseUrl, $url);
+        $decodedRepsonse         = $this->httpDownloader->get(
             $url,
             [
                 'retry-auth-failure' => true,
                 'http' => [
                     'method' => 'GET',
-                    'header' => $this->authHelper->addAuthenticationHeader([], $this->githubApiBaseUrl, $url),
+                    'header' => $authOptions['http']['header'],
                 ],
             ],
         )->decodeJson();
@@ -78,13 +79,14 @@ final class FetchPieReleaseFromGitHub implements FetchPieRelease
 
     public function downloadContent(ReleaseMetadata $releaseMetadata): BinaryFile
     {
+        $authOptions = $this->authHelper->addAuthenticationOptions([], $this->githubApiBaseUrl, $releaseMetadata->downloadUrl);
         $pharContent = $this->httpDownloader->get(
             $releaseMetadata->downloadUrl,
             [
                 'retry-auth-failure' => true,
                 'http' => [
                     'method' => 'GET',
-                    'header' => $this->authHelper->addAuthenticationHeader([], $this->githubApiBaseUrl, $releaseMetadata->downloadUrl),
+                    'header' => $authOptions['http']['header'],
                 ],
             ],
         )->getBody();

--- a/src/SelfManage/Verify/FallbackVerificationUsingOpenSsl.php
+++ b/src/SelfManage/Verify/FallbackVerificationUsingOpenSsl.php
@@ -282,13 +282,14 @@ final class FallbackVerificationUsingOpenSsl implements VerifyPiePhar
         $attestationUrl = $this->githubApiBaseUrl . '/orgs/php/attestations/sha256:' . $pharFilename->checksum;
 
         try {
-            $decodedJson = $this->httpDownloader->get(
+            $authOptions             = $this->authHelper->addAuthenticationOptions([], $this->githubApiBaseUrl, $attestationUrl);
+            $decodedJson             = $this->httpDownloader->get(
                 $attestationUrl,
                 [
                     'retry-auth-failure' => true,
                     'http' => [
                         'method' => 'GET',
-                        'header' => $this->authHelper->addAuthenticationHeader([], $this->githubApiBaseUrl, $attestationUrl),
+                        'header' => $authOptions['http']['header'],
                     ],
                 ],
             )->decodeJson();

--- a/test/unit/SelfManage/Update/FetchPieReleaseFromGitHubTest.php
+++ b/test/unit/SelfManage/Update/FetchPieReleaseFromGitHubTest.php
@@ -29,8 +29,8 @@ final class FetchPieReleaseFromGitHubTest extends TestCase
 
         $url = self::TEST_GITHUB_URL . '/repos/php/pie/releases/latest';
         $authHelper
-            ->method('addAuthenticationHeader')
-            ->willReturn(['Authorization: Bearer fake-token']);
+            ->method('addAuthenticationOptions')
+            ->willReturn(['http' => ['header' => ['Authorization: Bearer fake-token']]]);
         $httpDownloader->expects(self::once())
             ->method('get')
             ->with(
@@ -84,8 +84,8 @@ final class FetchPieReleaseFromGitHubTest extends TestCase
         $authHelper     = $this->createMock(AuthHelper::class);
 
         $authHelper
-            ->method('addAuthenticationHeader')
-            ->willReturn(['Authorization: Bearer fake-token']);
+            ->method('addAuthenticationOptions')
+            ->willReturn(['http' => ['header' => ['Authorization: Bearer fake-token']]]);
         $httpDownloader->expects(self::once())
             ->method('get')
             ->with(

--- a/test/unit/SelfManage/Verify/FallbackVerificationUsingOpenSslTest.php
+++ b/test/unit/SelfManage/Verify/FallbackVerificationUsingOpenSslTest.php
@@ -135,8 +135,8 @@ EOF);
     {
         $url = self::TEST_GITHUB_URL . '/orgs/php/attestations/sha256:' . $digestInUrl;
         $this->authHelper
-            ->method('addAuthenticationHeader')
-            ->willReturn(['Authorization: Bearer fake-token']);
+            ->method('addAuthenticationOptions')
+            ->willReturn(['http' => ['header' => ['Authorization: Bearer fake-token']]]);
         $this->httpDownloader->expects(self::once())
             ->method('get')
             ->with(
@@ -267,8 +267,8 @@ EOF);
         $transportException->setStatusCode(404);
 
         $this->authHelper
-            ->method('addAuthenticationHeader')
-            ->willReturn(['Authorization: Bearer fake-token']);
+            ->method('addAuthenticationOptions')
+            ->willReturn(['http' => ['header' => ['Authorization: Bearer fake-token']]]);
         $this->httpDownloader->expects(self::once())
             ->method('get')
             ->willThrowException($transportException);


### PR DESCRIPTION
### Description

This change updates usage of Composer::AuthHelper for [upcoming API-change](https://github.com/composer/composer/pull/12406), this PR resolves #244.

### Draft

We'll need to wait for couple things:
 - merge of composer-PR [#12406](https://github.com/composer/composer/pull/12406)
 - release of composer 2.9
 - update of PIE to composer 2.9