### PR TITLE
Run `composer bump`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,24 +28,24 @@
     ],
     "require": {
         "php": "8.1.*||8.2.*||8.3.*||8.4.*",
-        "composer/composer": "^2.8.6",
+        "composer/composer": "^2.8.9",
         "composer/pcre": "^3.3.2",
         "composer/semver": "^3.4.3",
         "fidry/cpu-core-counter": "^1.2",
         "illuminate/container": "^10.48.28",
         "psr/container": "^2.0.2",
-        "symfony/console": "^6.4.20",
+        "symfony/console": "^6.4.22",
         "symfony/event-dispatcher": "^6.4.13",
         "symfony/process": "^6.4.20",
         "webmozart/assert": "^1.11"
     },
     "require-dev": {
         "ext-openssl": "*",
-        "behat/behat": "^3.19.0",
-        "doctrine/coding-standard": "^13.0",
+        "behat/behat": "^3.22.0",
+        "doctrine/coding-standard": "^13.0.1",
         "phpunit/phpunit": "^10.5.45",
         "psalm/plugin-phpunit": "^0.19.5",
-        "vimeo/psalm": "^6.10.0"
+        "vimeo/psalm": "^6.12.0"
     },
     "replace": {
         "symfony/polyfill-php81": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "29ce0e36ea537bf3d89967a17def0e5d",
+    "content-hash": "f695b5b9d810040c8498d73ca7771431",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -7057,7 +7057,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
Apparently the `bump-after-update` setting is not (yet) respected by Dependabot.