### PR TITLE
Run `composer validate --strict` as part of the Static Analysis CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -99,6 +99,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v4
       - uses: ramsey/composer-install@v3
+      - name: Validate the composer configuration
+        run: composer validate --strict
       - name: Run Psalm
         run: vendor/bin/psalm
 


### PR DESCRIPTION
CI is expected to be red until #281 is merged.

----------------

This will ensure that the `composer.json` is in sync with `composer.lock` and thus is related to php/pie#281 and php/pie#277.