### PR TITLE
Force tags fetch to overcome tag confusion

### DIFF
--- a/.github/workflows/build-phar.yml
+++ b/.github/workflows/build-phar.yml
@@ -40,6 +40,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      # Fixes `git describe` picking the wrong tag - see https://github.com/php/pie/issues/307
+      - run: git fetch --tags --force
       # Ensure some kind of previous tag exists, otherwise box fails
       - run: git describe --tags HEAD || git tag 0.0.0
       - uses: ramsey/composer-install@v3


### PR DESCRIPTION
Fixes #307 

Example pipeline: https://github.com/asgrim/pie/actions/runs/17036702087/job/48290758897#step:5:9

```
Run git fetch --tags --force
From https://github.com/asgrim/pie
 t [tag update]      1.1.1      -> 1.1.1
0s
Run git describe --tags HEAD || git tag 0.0.0
1.1.1
```