### PR TITLE
Improve exception when using pre-packaged-source and a branch alias

### DIFF
--- a/src/Downloading/Exception/CouldNotFindReleaseAsset.php
+++ b/src/Downloading/Exception/CouldNotFindReleaseAsset.php
@@ -12,6 +12,8 @@ use RuntimeException;
 use function implode;
 use function sprintf;
 
+use const PHP_EOL;
+
 class CouldNotFindReleaseAsset extends RuntimeException
 {
     /** @param non-empty-list<non-empty-string> $expectedAssetNames */
@@ -37,6 +39,19 @@ class CouldNotFindReleaseAsset extends RuntimeException
 
     public static function forPackageWithMissingTag(Package $package): self
     {
+        if (
+            $package->downloadUrlMethod() === DownloadUrlMethod::PrePackagedSourceDownload
+            && $package->composerPackage()->isDev()
+        ) {
+            return new self(sprintf(
+                'The package %s uses pre-packaged source archives, which are not available for branch aliases such as %s. You should either omit the version constraint to use the latest compatible version, or use a tagged version instead. You can find a list of tagged versions on:%shttps://packagist.org/packages/%s',
+                $package->name(),
+                $package->version(),
+                PHP_EOL . PHP_EOL,
+                $package->name(),
+            ));
+        }
+
         return new self(sprintf(
             'Could not find release by tag name for %s',
             $package->prettyNameAndVersion(),


### PR DESCRIPTION
Fixes #306

This PR should improve the error message, e.g.:

```
  [Php\Pie\Downloading\Exception\CouldNotFindReleaseAsset]                                                       
  The package mongodb/mongodb-extension uses pre-packaged source archives, which are not available for branch a  
  liases such as v2.x-dev. You should either omit the version constraint to use the latest compatible version,   
  or use a tagged version instead. You can find a list of tagged versions on:                                    
                                                                                                                 
  https://packagist.org/packages/mongodb/mongodb-extension
```

This should hopefully help prevent any further confusion! 