### PR TITLE
docs: add php-dev as dependency on Debian/Ubuntu systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ On Linux, you will need a build toolchain installed. On Debian/Ubuntu type
 systems, you could run something like:
 
 ```shell
-sudo apt install gcc make autoconf libtool bison re2c pkg-config
+sudo apt install gcc make autoconf libtool bison re2c pkg-config php-dev
 ```
 
 On Windows, you do not need any build toolchain installed, since PHP extensions


### PR DESCRIPTION
This commit adds `php-dev` as a dependency on Debian/Ubuntu systems, so the following error message is fixed:

<img width="1950" height="386" alt="image" src="https://github.com/user-attachments/assets/b9e806fd-8e80-47c7-8cd5-e1ddbfe46547" />
