### PR TITLE
De-duplicate docker image build for nightly and release tags

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -1,13 +1,18 @@
 # Invoking this pipeline requires additional permissions, so must be invoked
 # in a way to pass those permissions on, e.g.:
 #
-#  build-phar:
+#  build-and-push-docker-image:
+#    needs: build-phar
 #    permissions:
 #      contents: read
 #      id-token: write
 #      attestations: write
 #      packages: write
 #    uses: ./.github/workflows/build-and-push-docker-image.yml
+#    with:
+#      tags: |
+#        type=raw,value=bin
+#        type=semver,pattern={{version}}-bin
 
 name: "Build and push the PIE Docker Image"
 

--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -1,0 +1,92 @@
+# Invoking this pipeline requires additional permissions, so must be invoked
+# in a way to pass those permissions on, e.g.:
+#
+#  build-phar:
+#    permissions:
+#      contents: read
+#      id-token: write
+#      attestations: write
+#      packages: write
+#    uses: ./.github/workflows/build-and-push-docker-image.yml
+
+name: "Build and push the PIE Docker Image"
+
+on:
+  workflow_call:
+    inputs:
+      tags:
+        description: Tag definition - see docker/metadata-action
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  docker-binary-only-image:
+    name: Docker binary-only image
+    runs-on: ubuntu-latest
+
+    permissions:
+      # attestations:write is required for build provenance attestation.
+      attestations: write
+      # id-token:write is required for build provenance attestation.
+      id-token: write
+      # packages:write is required to publish Docker images to GitHub's registry.
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Fetch built PHAR from artifacts
+        uses: actions/download-artifact@v5
+        with:
+          name: pie-${{ github.sha }}.phar
+
+      - name: Verify the PHAR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh attestation verify pie.phar --repo ${{ github.repository }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          flavor: |
+            latest=false
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            ${{ inputs.tags }}
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          file: Dockerfile
+          target: standalone-binary
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.build-and-push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/docker-nightly-image-push.yml
+++ b/.github/workflows/docker-nightly-image-push.yml
@@ -1,0 +1,34 @@
+name: "Nightly Docker Image Build"
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-phar:
+    # See build-phar.yml for a list of the permissions and why they are needed
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    uses: ./.github/workflows/build-phar.yml
+
+  build-and-push-docker-image:
+    needs: build-phar
+    # See build-and-push-docker-image.yml for a list of the permissions and why they are needed
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+      packages: write
+    uses: ./.github/workflows/build-and-push-docker-image.yml
+    with:
+      tags: |
+        type=raw,value=nightly-bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,76 +39,20 @@ jobs:
         with:
           files: pie.phar
 
-  docker-binary-only-image:
-    needs: build-phar
-    name: Docker binary-only image
-    runs-on: ubuntu-latest
+  build-and-push-docker-image:
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
-
+    needs: build-phar
+    # See build-and-push-docker-image.yml for a list of the permissions and why they are needed
     permissions:
-      # attestations:write is required for build provenance attestation.
-      attestations: write
-      # id-token:write is required for build provenance attestation.
+      contents: read
       id-token: write
-      # packages:write is required to publish Docker images to GitHub's registry.
+      attestations: write
       packages: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-
-      - name: Fetch built PHAR from artifacts
-        uses: actions/download-artifact@v5
-        with:
-          name: pie-${{ github.sha }}.phar
-
-      - name: Verify the PHAR
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh attestation verify pie.phar --repo ${{ github.repository }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          flavor: |
-            latest=false
-          images: ghcr.io/${{ github.repository }}
-          # @TODO v1.0 Consider introducing more granular tags (major and major.minor)
-          # @see https://github.com/php/pie/pull/122#pullrequestreview-2477496308
-          # @see https://github.com/php/pie/pull/122#discussion_r1867331273
-          tags: |
-            type=raw,value=bin
-            type=semver,pattern={{version}}-bin
-
-      - name: Build and push Docker image
-        id: build-and-push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          file: Dockerfile
-          target: standalone-binary
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v3
-        with:
-          subject-name: ghcr.io/${{ github.repository }}
-          subject-digest: ${{ steps.build-and-push.outputs.digest }}
-          push-to-registry: true
+    uses: ./.github/workflows/build-and-push-docker-image.yml
+    with:
+      # @TODO v1.0 Consider introducing more granular tags (major and major.minor)
+      # @see https://github.com/php/pie/pull/122#pullrequestreview-2477496308
+      # @see https://github.com/php/pie/pull/122#discussion_r1867331273
+      tags: |
+        type=raw,value=bin
+        type=semver,pattern={{version}}-bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,5 +54,5 @@ jobs:
       # @see https://github.com/php/pie/pull/122#pullrequestreview-2477496308
       # @see https://github.com/php/pie/pull/122#discussion_r1867331273
       tags: |
-        type=raw,value=bin
+        ${{ ((!contains(github.ref, 'alpha') && !contains(github.ref, 'beta') && !contains(github.ref, 'rc')) && 'type=raw,value=bin') || '' }}
         type=semver,pattern={{version}}-bin


### PR DESCRIPTION
Fixes #323

Fixes #334 

Supersedes #349 

Sorry for splitting into a new PR @alexandre-daubois - was quicker to just do this rather than provide direction as I already had a plan for this ticket. This approach just avoids all the duplication in #349  - also, it makes no sense IMO to actually run it every night on schedule, just whenever `main` is merged to (same as the nightly PHAR build) - 