### PR TITLE
Fix handling of additional INI directory files

### DIFF
--- a/src/Installing/Ini/RemoveIniEntryWithFileGetContents.php
+++ b/src/Installing/Ini/RemoveIniEntryWithFileGetContents.php
@@ -19,6 +19,7 @@ use function file_exists;
 use function file_get_contents;
 use function in_array;
 use function is_array;
+use function is_dir;
 use function preg_replace;
 use function scandir;
 use function sprintf;
@@ -39,7 +40,7 @@ class RemoveIniEntryWithFileGetContents implements RemoveIniEntry
         }
 
         $additionalIniDirectory = $targetPlatform->phpBinaryPath->additionalIniDirectory();
-        if ($additionalIniDirectory !== null) {
+        if ($additionalIniDirectory !== null && file_exists($additionalIniDirectory) && is_dir($additionalIniDirectory)) {
             $filenames = scandir($additionalIniDirectory);
             if (is_array($filenames)) {
                 $allIniFiles = array_merge(

--- a/test/unit/Installing/Ini/RemoveIniEntryWithFileGetContentsTest.php
+++ b/test/unit/Installing/Ini/RemoveIniEntryWithFileGetContentsTest.php
@@ -128,6 +128,46 @@ final class RemoveIniEntryWithFileGetContentsTest extends TestCase
         );
     }
 
+    #[DataProvider('extensionTypeProvider')]
+    public function testNonExistentAdditionalIniDirectoryDoesNotCrash(ExtensionType $extensionType): void
+    {
+        $phpBinaryPath = $this->createMock(PhpBinaryPath::class);
+        $phpBinaryPath
+            ->method('loadedIniConfigurationFile')
+            ->willReturn(null);
+        $phpBinaryPath
+            ->method('additionalIniDirectory')
+            ->willReturn('/this/path/should/not/exist/for/testing');
+
+        $package = new Package(
+            $this->createMock(CompletePackageInterface::class),
+            $extensionType,
+            ExtensionName::normaliseFromString('foobar'),
+            'foobar/foobar',
+            '1.2.3',
+            null,
+        );
+
+        $targetPlatform = new TargetPlatform(
+            OperatingSystem::NonWindows,
+            OperatingSystemFamily::Linux,
+            $phpBinaryPath,
+            Architecture::x86_64,
+            ThreadSafetyMode::ThreadSafe,
+            1,
+            null,
+        );
+
+        self::assertSame(
+            [],
+            (new RemoveIniEntryWithFileGetContents())(
+                $package,
+                $targetPlatform,
+                $this->createMock(OutputInterface::class),
+            ),
+        );
+    }
+
     #[RequiresOperatingSystemFamily('Linux')]
     public function testSymlinkedIniFilesAreResolved(): void
     {


### PR DESCRIPTION
PHP_INI_SCAN_DIR may contain a non-existing directory in the list.

This PR fixes handling of additional INI directory filesby checking if filenames are an array.

I personally experienced fatal error because I had this config:
```
PHP_INI_SCAN_DIR => ~/.config/herd-lite/bin:
_ => /opt/homebrew/bin/php
```
I have removed `herd-lite`, but my php config contained a reference to the ~/.config/herd-lite/bin 


____
The original issue caused by the export PHP_INI_SCAN_DIR=... in my ` ~/.zshrc`, added by herd-lite and not removed on uninstall (#https://github.com/beyondcode/herd-community/issues/11)