### PR TITLE
Ensure php/ bundled dependencies can be installed on unstable PHPs

### DIFF
--- a/src/Command/InfoCommand.php
+++ b/src/Command/InfoCommand.php
@@ -131,7 +131,7 @@ final class InfoCommand extends Command
             $platformConstraints = [];
             $composerPlatform    = new PhpBinaryPathBasedPlatformRepository($targetPlatform->phpBinaryPath, $composer, new InstalledPiePackages(), null);
             foreach ($composerPlatform->getPackages() as $platformPackage) {
-                $platformConstraints[$platformPackage->getName()][] = new Constraint('==', $platformPackage->getPrettyVersion());
+                $platformConstraints[$platformPackage->getName()][] = new Constraint('==', $platformPackage->getVersion());
             }
 
             foreach ($requires as $requireName => $requireLink) {

--- a/src/ComposerIntegration/VersionSelectorFactory.php
+++ b/src/ComposerIntegration/VersionSelectorFactory.php
@@ -20,9 +20,9 @@ final class VersionSelectorFactory
     {
     }
 
-    private static function factoryRepositorySet(Composer $composer, string|null $requestedVersion): RepositorySet
+    private static function factoryRepositorySet(Composer $composer, RequestedPackageAndVersion $requestedPackageAndVersion): RepositorySet
     {
-        $repositorySet = new RepositorySet(DetermineMinimumStability::fromRequestedVersion($requestedVersion));
+        $repositorySet = new RepositorySet(DetermineMinimumStability::fromRequestedVersion($requestedPackageAndVersion));
         $repositorySet->addRepository(new CompositeRepository($composer->getRepositoryManager()->getRepositories()));
 
         return $repositorySet;
@@ -34,7 +34,7 @@ final class VersionSelectorFactory
         TargetPlatform $targetPlatform,
     ): VersionSelector {
         return new VersionSelector(
-            self::factoryRepositorySet($composer, $requestedPackageAndVersion->version),
+            self::factoryRepositorySet($composer, $requestedPackageAndVersion),
             new PhpBinaryPathBasedPlatformRepository($targetPlatform->phpBinaryPath, $composer, new InstalledPiePackages(), null),
         );
     }

--- a/src/DependencyResolver/DetermineMinimumStability.php
+++ b/src/DependencyResolver/DetermineMinimumStability.php
@@ -7,6 +7,8 @@ namespace Php\Pie\DependencyResolver;
 use Composer\Semver\VersionParser;
 use Webmozart\Assert\Assert;
 
+use function str_starts_with;
+
 /**
  * Utility to extract a valid Stability (see {@see \Composer\Package\BasePackage::$stabilities}) from a requested
  * package version in a predictable way.
@@ -39,13 +41,17 @@ final class DetermineMinimumStability
     }
 
     /** @return self::STABILITY_* */
-    public static function fromRequestedVersion(string|null $requestedVersion): string
+    public static function fromRequestedVersion(RequestedPackageAndVersion $requestedPackageAndVersion): string
     {
-        if ($requestedVersion === null) {
+        if ($requestedPackageAndVersion->version === null) {
+            if (str_starts_with($requestedPackageAndVersion->package, 'php/')) {
+                return self::STABILITY_DEV;
+            }
+
             return self::DEFAULT_MINIMUM_STABILITY;
         }
 
-        $stability = VersionParser::parseStability($requestedVersion);
+        $stability = VersionParser::parseStability($requestedPackageAndVersion->version);
         self::assertValidStabilityString($stability);
 
         return $stability;

--- a/src/DependencyResolver/UnableToResolveRequirement.php
+++ b/src/DependencyResolver/UnableToResolveRequirement.php
@@ -30,7 +30,7 @@ class UnableToResolveRequirement extends RuntimeException
                 'Unable to find an installable package %s for %s, with minimum stability %s.%s',
                 $requestedPackageAndVersion->package,
                 $requestedPackageAndVersion->version !== null ? sprintf('version %s', $requestedPackageAndVersion->version) : 'the latest compatible version',
-                DetermineMinimumStability::fromRequestedVersion($requestedPackageAndVersion->version),
+                DetermineMinimumStability::fromRequestedVersion($requestedPackageAndVersion),
                 count($errors) ? "\n\n" . implode("\n\n", $errors) : '',
             ),
             $requestedPackageAndVersion,

--- a/test/unit/DependencyResolver/DetermineMinimumStabilityTest.php
+++ b/test/unit/DependencyResolver/DetermineMinimumStabilityTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Php\PieUnitTest\DependencyResolver;
 
 use Php\Pie\DependencyResolver\DetermineMinimumStability;
+use Php\Pie\DependencyResolver\RequestedPackageAndVersion;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -15,31 +16,36 @@ use function array_map;
 #[CoversClass(DetermineMinimumStability::class)]
 final class DetermineMinimumStabilityTest extends TestCase
 {
-    /** @return array<string, array{0: non-empty-string|null, 1: non-empty-string}> */
+    /** @return array<string, array{0: RequestedPackageAndVersion, 1: non-empty-string}> */
     public static function requestedVersionToStabilityProvider(): array
     {
         $providerCases = [
-            [null, 'stable'],
-            ['1.2.3', 'stable'],
-            ['1.2.3@stable', 'stable'],
-            ['1.2.3@RC', 'RC'],
-            ['1.2.3@rc', 'RC'],
-            ['1.2.3@beta', 'beta'],
-            ['1.2.3@alpha', 'alpha'],
-            ['1.2.3@dev', 'dev'],
-            ['*@stable', 'stable'],
-            ['*@RC', 'RC'],
-            ['*@rc', 'RC'],
-            ['*@beta', 'beta'],
-            ['*@alpha', 'alpha'],
-            ['*@dev', 'dev'],
-            ['dev-main', 'dev'],
-            ['v1.x-dev', 'dev'],
+            [new RequestedPackageAndVersion('foo/bar', '1.2.3'), 'stable'],
+            [new RequestedPackageAndVersion('foo/bar', '1.2.3@stable'), 'stable'],
+            [new RequestedPackageAndVersion('foo/bar', '1.2.3@RC'), 'RC'],
+            [new RequestedPackageAndVersion('foo/bar', '1.2.3@rc'), 'RC'],
+            [new RequestedPackageAndVersion('foo/bar', '1.2.3@beta'), 'beta'],
+            [new RequestedPackageAndVersion('foo/bar', '1.2.3@alpha'), 'alpha'],
+            [new RequestedPackageAndVersion('foo/bar', '1.2.3@dev'), 'dev'],
+            [new RequestedPackageAndVersion('foo/bar', '*@stable'), 'stable'],
+            [new RequestedPackageAndVersion('foo/bar', '*@RC'), 'RC'],
+            [new RequestedPackageAndVersion('foo/bar', '*@rc'), 'RC'],
+            [new RequestedPackageAndVersion('foo/bar', '*@beta'), 'beta'],
+            [new RequestedPackageAndVersion('foo/bar', '*@alpha'), 'alpha'],
+            [new RequestedPackageAndVersion('foo/bar', '*@dev'), 'dev'],
+            [new RequestedPackageAndVersion('foo/bar', 'dev-main'), 'dev'],
+            [new RequestedPackageAndVersion('foo/bar', 'v1.x-dev'), 'dev'],
+            [new RequestedPackageAndVersion('php/bz2', null), 'dev'],
+            [new RequestedPackageAndVersion('php/bz2', '*@stable'), 'stable'],
+            [new RequestedPackageAndVersion('php/bz2', '*@RC'), 'RC'],
+            [new RequestedPackageAndVersion('php/bz2', '*@beta'), 'beta'],
+            [new RequestedPackageAndVersion('php/bz2', '*@alpha'), 'alpha'],
+            [new RequestedPackageAndVersion('php/bz2', '*@dev'), 'dev'],
         ];
 
         return array_combine(
             array_map(
-                static fn (array $case) => $case[0] ?? 'null',
+                static fn (array $case) => $case[0]->package . ':' . ($case[0]->version ?? 'null'),
                 $providerCases,
             ),
             $providerCases,
@@ -47,11 +53,11 @@ final class DetermineMinimumStabilityTest extends TestCase
     }
 
     #[DataProvider('requestedVersionToStabilityProvider')]
-    public function testFromRequestedVersion(string|null $requestedVersion, string $expectedStability): void
+    public function testFromRequestedVersion(RequestedPackageAndVersion $requestedPackageAndVersion, string $expectedStability): void
     {
         self::assertSame(
             $expectedStability,
-            DetermineMinimumStability::fromRequestedVersion($requestedVersion),
+            DetermineMinimumStability::fromRequestedVersion($requestedPackageAndVersion),
         );
     }
 }


### PR DESCRIPTION
Non-`stable` dependency versions of PHP means the bundled PHP extensions cannot be installed, because default stability is stable, but the version parsed in `\Php\Pie\ComposerIntegration\BundledPhpExtensionsRepository` will result in non-`@stable` versions, meaning they are not available. This change sets the default stability for any requested `php/` bundled extension to `dev` (unless explicitly defined, for whatever reason that might be...).