### PR TITLE
Skip test when pie can't enable the extension

### DIFF
--- a/test/integration/Command/ShowCommandTest.php
+++ b/test/integration/Command/ShowCommandTest.php
@@ -19,6 +19,7 @@ use Webmozart\Assert\Assert;
 
 use function get_loaded_extensions;
 use function phpversion;
+use function str_contains;
 
 use const PHP_VERSION_ID;
 
@@ -69,6 +70,12 @@ final class ShowCommandTest extends TestCase
             '--with-php-config' => $phpConfig,
         ]);
         $installCommand->assertCommandIsSuccessful();
+
+        $outputString = $installCommand->getDisplay();
+
+        if (str_contains($outputString, 'NOT been automatically')) {
+            self::markTestSkipped('PIE couldn\'t automatically enable the extension');
+        }
 
         PieJsonEditor::fromTargetPlatform(
             PiePlatform\TargetPlatform::fromPhpBinaryPath(


### PR DESCRIPTION
On my CI, the test fails with:
```
1) Php\PieIntegrationTest\Command\ShowCommandTest::testExecuteWithAvailableUpdates
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
-%Aexample_pie_extension:%S (from %S asgrim/example-pie-extension:2.0.2%S) — new version %S available%A
+You are running PHP 8.2.30-dev
+Target PHP installation: 8.2.30-dev nts, on Linux/OSX/etc x86_64 (from /opt/PHP-8.2/bin/php)
+Using pie.json: /home/runner/.config/pie/php8.2_bb2d7043a416ad941854cb71942911fa/pie.json
+Tip: to include extensions in this list that PIE does not manage, use the --all flag.
+
+Loaded PIE extensions:
+(none)
+
+ ⚠️  PIE packages not loaded:
+These extensions were installed with PIE but are not currently enabled.
+
+ - asgrim/example-pie-extension:2.0.2
```

I've been able to replicate the test failure locally and it happens when no .ini directory is configured *and* no php.ini file is present. When the tests installs the example extension, PIE warns that:
```
⚠️  Extension has NOT been automatically enabled.
You must now add "extension=example_pie_extension" to your php.ini
```

And the following assertion fails because they expect the extension to be loaded. I've decided to mark the test skipped when that happens, but perhaps additionally, PIE could be improved to create a php.ini when missing -- unless the case is not handled by design.