### PR TITLE
Allow dot in the path

### DIFF
--- a/test/behaviour/CliContext.php
+++ b/test/behaviour/CliContext.php
@@ -133,7 +133,7 @@ class CliContext implements Context
         if (Platform::isWindows()) {
             Assert::regex($this->output, '#👋 Removed extension: [-\\\_:.a-zA-Z0-9]+\\\php_example_pie_extension.dll#');
         } else {
-            Assert::regex($this->output, '#👋 Removed extension: [-_a-zA-Z0-9/]+/example_pie_extension.so#');
+            Assert::regex($this->output, '#👋 Removed extension: [-_.a-zA-Z0-9/]+/example_pie_extension.so#');
         }
 
         $isExtEnabled = (new Process([self::PHP_BINARY, '-r', 'echo extension_loaded("example_pie_extension")?"yes":"no";']))
@@ -156,7 +156,7 @@ class CliContext implements Context
             return;
         }
 
-        Assert::regex($this->output, '#Install complete: [-_a-zA-Z0-9/]+/example_pie_extension.so#');
+        Assert::regex($this->output, '#Install complete: [-_.a-zA-Z0-9/]+/example_pie_extension.so#');
 
         $isExtEnabled = (new Process([self::PHP_BINARY, '-r', 'echo extension_loaded("example_pie_extension")?"yes":"no";']))
             ->mustRun()


### PR DESCRIPTION
Apologies for the silly PRs!

My PHP path has a dot (`/opt/PHP-8.5`) and behat wasn't very happy about it.

```
001 Example: An extension can be installed          # features/install-extensions.feature:34
      Then the extension should have been installed # features/install-extensions.feature:36
        The value "🥧 PHP Installer for Extensions (PIE) dev-main, from The PHP Foundation
        You are running PHP 8.5.0-dev
        Target PHP installation: 8.5.0-dev nts, on Linux/OSX/etc x86_64 (from /opt/PHP-8.5/bin/php)
        Found package: asgrim/example-pie-extension:2.0.5 which provides ext-example_pie_extension
        Extracted asgrim/example-pie-extension:2.0.5 source to: /home/runner/.config/pie/php8.5_fdcc3311843d1f924fbcde941ed929bc/vendor/asgrim/example-pie-extension
        phpize complete.
        Configure complete with options: --with-php-config=/usr/bin/php-config
        Build complete: /home/runner/.config/pie/php8.5_fdcc3311843d1f924fbcde941ed929bc/vendor/asgrim/example-pie-extension/modules/example_pie_extension.so
        Install complete: /opt/PHP-8.5/lib/php/extensions/debug-non-zts-20250925/example_pie_extension.so
        ✅ Extension is enabled and loaded in /opt/PHP-8.5/bin/php
        " does not match the expected pattern. (Webmozart\Assert\InvalidArgumentException)
002 Example: An extension can be uninstalled             # features/uninstall-extensions.feature:3
      Then the extension should not be installed anymore # features/uninstall-extensions.feature:6
        The value "🥧 PHP Installer for Extensions (PIE) dev-main, from The PHP Foundation
        You are running PHP 8.5.0-dev
        Target PHP installation: 8.5.0-dev nts, on Linux/OSX/etc x86_64 (from /opt/PHP-8.5/bin/php)
        👋 Removed extension: /opt/PHP-8.5/lib/php/extensions/debug-non-zts-20250925/example_pie_extension.so
        " does not match the expected pattern. (Webmozart\Assert\InvalidArgumentException)
```