### PR TITLE
Handle box git version formatting properly in self-update

### DIFF
--- a/src/SelfManage/Update/ReleaseIsNewer.php
+++ b/src/SelfManage/Update/ReleaseIsNewer.php
@@ -7,6 +7,7 @@ namespace Php\Pie\SelfManage\Update;
 use Composer\Semver\Semver;
 use Composer\Semver\VersionParser;
 
+use function preg_match;
 use function strtolower;
 
 /** @internal This is not public API for PIE, so should not be depended upon unless you accept the risk of BC breaks */
@@ -31,6 +32,10 @@ class ReleaseIsNewer
         string $currentPieVersion,
         ReleaseMetadata $newRelease,
     ): bool {
+        if (preg_match('#([0-9]+\.[0-9]+\.[0-9]+)@([a-f0-9]{7})#', $currentPieVersion, $matches)) {
+            $currentPieVersion = 'dev-main#' . $matches[2];
+        }
+
         $newVersion   = $newRelease->tag;
         $newStability = self::stabilityToChannel(VersionParser::parseStability($newVersion));
 

--- a/test/unit/SelfManage/Update/ReleaseIsNewerTest.php
+++ b/test/unit/SelfManage/Update/ReleaseIsNewerTest.php
@@ -31,6 +31,9 @@ final class ReleaseIsNewerTest extends TestCase
             'stable-nightly-to-nightly'        => [Channel::Stable, 'dev-main', 'dev-main', false],
             'stable-nightly-to-stable'         => [Channel::Stable, 'dev-main', '1.0.0', true],
             'stable-nightly-to-preview'        => [Channel::Stable, 'dev-main', '1.0.1-rc1', false],
+            'stable-nightly2-to-nightly'       => [Channel::Stable, '1.2.1@86e1b52', 'dev-main', false],
+            'stable-nightly2-to-stable'        => [Channel::Stable, '1.2.1@86e1b52', '1.0.0', true],
+            'stable-nightly2-to-preview'       => [Channel::Stable, '1.2.1@86e1b52', '1.0.1-rc1', false],
 
             'preview-oldstable-to-newstable'   => [Channel::Preview, '1.0.0', '1.0.1', true],
             'preview-newstable-to-oldstable'   => [Channel::Preview, '1.0.1', '1.0.0', false],
@@ -45,6 +48,9 @@ final class ReleaseIsNewerTest extends TestCase
             'preview-nightly-to-nightly'       => [Channel::Preview, 'dev-main', 'dev-main', false],
             'preview-nightly-to-stable'        => [Channel::Preview, 'dev-main', '1.0.0', true],
             'preview-nightly-to-preview'       => [Channel::Preview, 'dev-main', '1.0.1-rc1', true],
+            'preview-nightly2-to-nightly'      => [Channel::Preview, '1.2.1@86e1b52', 'dev-main', false],
+            'preview-nightly2-to-stable'       => [Channel::Preview, '1.2.1@86e1b52', '1.0.0', true],
+            'preview-nightly2-to-preview'      => [Channel::Preview, '1.2.1@86e1b52', '1.0.1-rc1', true],
 
             'nightly-oldstable-to-newstable'   => [Channel::Nightly, '1.0.0', '1.0.1', true],
             'nightly-newstable-to-oldstable'   => [Channel::Nightly, '1.0.1', '1.0.0', false],
@@ -59,6 +65,9 @@ final class ReleaseIsNewerTest extends TestCase
             'nightly-nightly-to-nightly'       => [Channel::Nightly, 'dev-main', 'dev-main', true],
             'nightly-nightly-to-stable'        => [Channel::Nightly, 'dev-main', '1.0.0', false],
             'nightly-nightly-to-preview'       => [Channel::Nightly, 'dev-main', '1.0.1-rc1', false],
+            'nightly-nightly2-to-nightly'      => [Channel::Nightly, '1.2.1@86e1b52', 'dev-main', true],
+            'nightly-nightly2-to-stable'       => [Channel::Nightly, '1.2.1@86e1b52', '1.0.0', false],
+            'nightly-nightly2-to-preview'      => [Channel::Nightly, '1.2.1@86e1b52', '1.0.1-rc1', false],
         ];
     }
 


### PR DESCRIPTION
Handle box git version formatting (e.g. `1.2.1@<git>`) when running self-update