### PR TITLE
Skip test with no known /usr/bin/php-configX.Y

### DIFF
--- a/test/unit/Platform/TargetPhp/PhpBinaryPathTest.php
+++ b/test/unit/Platform/TargetPhp/PhpBinaryPathTest.php
@@ -135,6 +135,10 @@ final class PhpBinaryPathTest extends TestCase
                 && is_executable($phpConfigPath[0]),
         );
 
+        if ($possiblePhpConfigPaths === []) {
+            return ['skip' => ['skip', 'skip']];
+        }
+
         return array_combine(
             array_column($possiblePhpConfigPaths, 0),
             $possiblePhpConfigPaths,
@@ -146,6 +150,10 @@ final class PhpBinaryPathTest extends TestCase
     {
         if (Platform::isWindows()) {
             self::markTestSkipped('Do not need to test php-config on Windows as we are not building on Windows.');
+        }
+
+        if ($expectedMajorMinor === 'skip') {
+            self::markTestSkipped('No known system php-config could be found.');
         }
 
         assert($phpConfigPath !== '');


### PR DESCRIPTION
I was still getting random failures due to `php -i` taking more than 5 seconds and I tracked down the issue to a test using other available versions of php-config on the system.

Once removed the system php, this data provider returned an empty array, and phpunit is not happy about it.

Cheers