### PR TITLE
446: Fix versions not parsing when PHP_VERSION is not semver-compat

### DIFF
--- a/src/Platform/TargetPhp/PhpBinaryPath.php
+++ b/src/Platform/TargetPhp/PhpBinaryPath.php
@@ -299,7 +299,7 @@ PHP,
         $phpVersion = self::cleanWarningAndDeprecationsFromOutput(Process::run([
             $this->phpBinaryPath,
             '-r',
-            'echo PHP_VERSION;',
+            'echo PHP_MAJOR_VERSION . "." . PHP_MINOR_VERSION . "." . PHP_RELEASE_VERSION;',
         ]));
         Assert::stringNotEmpty($phpVersion, 'Could not determine PHP version');
 

--- a/test/assets/fake-php-invalid-version.sh
+++ b/test/assets/fake-php-invalid-version.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+ARGS="$*"
+
+case "$ARGS" in
+    "-r echo \"PHP\";")
+      echo "PHP";
+      exit 0
+      ;;
+    "-r echo PHP_VERSION;")
+      echo "5.6.40-90+ubuntu24.04.1+deb.sury.org+1";
+      exit 0
+      ;;
+    "-r echo PHP_MAJOR_VERSION . \".\" . PHP_MINOR_VERSION . \".\" . PHP_RELEASE_VERSION;")
+      echo "5.6.40";
+      exit 0
+      ;;
+    "-r echo PHP_MAJOR_VERSION . \".\" . PHP_MINOR_VERSION;")
+      echo "5.6";
+      exit 0
+      ;;
+    *)
+      echo "unknown fake php command: $ARGS"
+      exit 1
+esac
+

--- a/test/integration/Command/InstallCommandTest.php
+++ b/test/integration/Command/InstallCommandTest.php
@@ -50,6 +50,8 @@ class InstallCommandTest extends TestCase
         $possiblePhpConfigPaths = array_filter(
             [
                 '/usr/bin/php-config',
+                '/usr/bin/php-config8.5',
+                '/usr/bin/php-config8.4',
                 '/usr/bin/php-config8.3',
                 '/usr/bin/php-config8.2',
                 '/usr/bin/php-config8.1',

--- a/test/integration/Installing/UnixInstallTest.php
+++ b/test/integration/Installing/UnixInstallTest.php
@@ -47,12 +47,15 @@ final class UnixInstallTest extends TestCase
         $possiblePhpConfigPaths = array_filter(
             [
                 '/usr/bin/php-config',
+                '/usr/bin/php-config8.5',
                 '/usr/bin/php-config8.4',
                 '/usr/bin/php-config8.3',
                 '/usr/bin/php-config8.2',
                 '/usr/bin/php-config8.1',
                 '/usr/bin/php-config8.0',
                 '/usr/bin/php-config7.4',
+                '/usr/bin/php-config7.3',
+                '/usr/bin/php-config7.2',
             ],
             static fn (string $phpConfigPath) => file_exists($phpConfigPath)
                 && is_executable($phpConfigPath),

--- a/test/unit/Platform/TargetPhp/PhpBinaryPathTest.php
+++ b/test/unit/Platform/TargetPhp/PhpBinaryPathTest.php
@@ -57,6 +57,7 @@ use const PHP_VERSION;
 final class PhpBinaryPathTest extends TestCase
 {
     private const FAKE_PHP_EXECUTABLE     = __DIR__ . '/../../../assets/fake-php.sh';
+    private const PHP_INVALID_VERSION     = __DIR__ . '/../../../assets/fake-php-invalid-version.sh';
     private const VALID_PHP_WITH_WARNINGS = __DIR__ . '/../../../assets/valid-php-with-warnings.sh';
 
     public function testNonExistentPhpBinaryIsRejected(): void
@@ -90,6 +91,13 @@ final class PhpBinaryPathTest extends TestCase
         $this->expectException(InvalidPhpBinaryPath::class);
         $this->expectExceptionMessage('does not appear to be a PHP binary');
         PhpBinaryPath::fromPhpBinaryPath(self::FAKE_PHP_EXECUTABLE);
+    }
+
+    public function testInvalidVersion(): void
+    {
+        $phpBinary = PhpBinaryPath::fromPhpBinaryPath(self::PHP_INVALID_VERSION);
+        self::assertSame('5.6.40', $phpBinary->version());
+        self::assertSame('5.6', $phpBinary->majorMinorVersion());
     }
 
     public function testWarningsAndDeprecationsAreFiltered(): void
@@ -129,11 +137,17 @@ final class PhpBinaryPathTest extends TestCase
 
         $possiblePhpConfigPaths = array_filter(
             [
+                ['/usr/bin/php-config8.5', '8.5'],
+                ['/usr/bin/php-config8.4', '8.4'],
                 ['/usr/bin/php-config8.3', '8.3'],
                 ['/usr/bin/php-config8.2', '8.2'],
                 ['/usr/bin/php-config8.1', '8.1'],
                 ['/usr/bin/php-config8.0', '8.0'],
                 ['/usr/bin/php-config7.4', '7.4'],
+                ['/usr/bin/php-config7.3', '7.3'],
+                ['/usr/bin/php-config7.2', '7.2'],
+                ['/usr/bin/php-config7.1', '7.1'],
+                ['/usr/bin/php-config5.6', '5.6'],
             ],
             static fn (array $phpConfigPath) => file_exists($phpConfigPath[0])
                 && is_executable($phpConfigPath[0]),
@@ -166,6 +180,11 @@ final class PhpBinaryPathTest extends TestCase
         self::assertSame(
             $expectedMajorMinor,
             $phpBinary->majorMinorVersion(),
+        );
+
+        self::assertStringStartsWith(
+            $expectedMajorMinor . '.',
+            $phpBinary->version(),
         );
 
         self::assertSame($phpConfigPath, $phpBinary->phpConfigPath());

--- a/test/unit/Platform/TargetPhp/PhpBinaryPathTest.php
+++ b/test/unit/Platform/TargetPhp/PhpBinaryPathTest.php
@@ -86,6 +86,7 @@ final class PhpBinaryPathTest extends TestCase
         PhpBinaryPath::fromPhpBinaryPath(__FILE__);
     }
 
+    #[RequiresOperatingSystemFamily('Linux')]
     public function testInvalidPhpBinaryIsRejected(): void
     {
         $this->expectException(InvalidPhpBinaryPath::class);
@@ -93,6 +94,7 @@ final class PhpBinaryPathTest extends TestCase
         PhpBinaryPath::fromPhpBinaryPath(self::FAKE_PHP_EXECUTABLE);
     }
 
+    #[RequiresOperatingSystemFamily('Linux')]
     public function testInvalidVersion(): void
     {
         $phpBinary = PhpBinaryPath::fromPhpBinaryPath(self::PHP_INVALID_VERSION);


### PR DESCRIPTION
Fixes #446 

Reverts commit 2962d921bec1223c7b6df96404e9be28edfc34c1

Presumably this was changed for simplicity, but there was no test to ensure any PHP builds with non-semver-compatible version strings don't crash