### PR TITLE
Strip suffix when comparing versions

### DIFF
--- a/test/unit/Platform/TargetPhp/PhpBinaryPathTest.php
+++ b/test/unit/Platform/TargetPhp/PhpBinaryPathTest.php
@@ -51,7 +51,7 @@ use const PHP_INT_SIZE;
 use const PHP_MAJOR_VERSION;
 use const PHP_MINOR_VERSION;
 use const PHP_OS_FAMILY;
-use const PHP_VERSION;
+use const PHP_RELEASE_VERSION;
 
 #[CoversClass(PhpBinaryPath::class)]
 final class PhpBinaryPathTest extends TestCase
@@ -117,7 +117,7 @@ final class PhpBinaryPathTest extends TestCase
         $phpBinary = PhpBinaryPath::fromCurrentProcess();
 
         self::assertSame(
-            PHP_VERSION,
+            PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION . '.' . PHP_RELEASE_VERSION,
             $phpBinary->version(),
         );
 


### PR DESCRIPTION
```
1) Php\PieUnitTest\Platform\TargetPhp\PhpBinaryPathTest::testVersionFromCurrentProcess
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'8.5.3-dev'
+'8.5.3'
```

:-)