### PR TITLE
436: add forward compatibility for download-url-method having a list

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -421,6 +421,18 @@ parameters:
 			path: test/unit/ComposerIntegration/VendorCleanupTest.php
 
 		-
+			message: '#^Parameter \#1 \$phpExt of method Composer\\Package\\Package\:\:setPhpExt\(\) expects array\{extension\-name\?\: string, priority\?\: int, support\-zts\?\: bool, support\-nts\?\: bool, build\-path\?\: string\|null, download\-url\-method\?\: string, os\-families\?\: non\-empty\-list\<non\-empty\-string\>, os\-families\-exclude\?\: non\-empty\-list\<non\-empty\-string\>, \.\.\.\}\|null, array\{download\-url\-method\: array\{''composer\-default''\}\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: test/unit/DependencyResolver/PackageTest.php
+
+		-
+			message: '#^Parameter \#1 \$phpExt of method Composer\\Package\\Package\:\:setPhpExt\(\) expects array\{extension\-name\?\: string, priority\?\: int, support\-zts\?\: bool, support\-nts\?\: bool, build\-path\?\: string\|null, download\-url\-method\?\: string, os\-families\?\: non\-empty\-list\<non\-empty\-string\>, os\-families\-exclude\?\: non\-empty\-list\<non\-empty\-string\>, \.\.\.\}\|null, array\{download\-url\-method\: array\{''pre\-packaged\-source'', ''composer\-default''\}\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: test/unit/DependencyResolver/PackageTest.php
+
+		-
 			message: '#^Parameter \#2 \$extractedSourcePath of static method Php\\Pie\\Downloading\\DownloadedPackage\:\:fromPackageAndExtractedPath\(\) expects string, string\|false given\.$#'
 			identifier: argument.type
 			count: 3

--- a/src/DependencyResolver/Package.php
+++ b/src/DependencyResolver/Package.php
@@ -16,8 +16,10 @@ use Webmozart\Assert\Assert;
 use function array_key_exists;
 use function array_map;
 use function array_slice;
+use function count;
 use function explode;
 use function implode;
+use function is_array;
 use function parse_url;
 use function str_contains;
 use function str_starts_with;
@@ -89,7 +91,17 @@ final class Package
         $package->priority = $phpExtOptions['priority'] ?? 80;
 
         if ($phpExtOptions !== null && array_key_exists('download-url-method', $phpExtOptions)) {
-            $package->downloadUrlMethod = DownloadUrlMethod::tryFrom($phpExtOptions['download-url-method']);
+            /** @var string|list<string> $method */
+            $method = $phpExtOptions['download-url-method'];
+            if (is_array($method)) {
+                if (count($method) !== 1) {
+                    throw new InvalidArgumentException('This extension requires a newer version of PIE. Multiple download-url-methods are not supported until PIE 1.4.0.');
+                }
+
+                $method = $method[0];
+            }
+
+            $package->downloadUrlMethod = DownloadUrlMethod::tryFrom($method);
         }
 
         return $package;

--- a/test/unit/DependencyResolver/PackageTest.php
+++ b/test/unit/DependencyResolver/PackageTest.php
@@ -8,6 +8,7 @@ use Composer\Package\CompletePackage;
 use Composer\Package\CompletePackageInterface;
 use InvalidArgumentException;
 use Php\Pie\DependencyResolver\Package;
+use Php\Pie\Downloading\DownloadUrlMethod;
 use Php\Pie\ExtensionName;
 use Php\Pie\ExtensionType;
 use Php\Pie\Platform\OperatingSystemFamily;
@@ -145,5 +146,35 @@ final class PackageTest extends TestCase
 
         self::assertSame('vendor/foo:1.2.3', $package->prettyNameAndVersion());
         self::assertSame('some/subdirectory/path/', $package->buildPath());
+    }
+
+    public function testDownloadUrlMethodWithStringHasValidDownloadUrlMethod(): void
+    {
+        $composerCompletePackage = new CompletePackage('vendor/foo', '1.2.3.0', '1.2.3');
+        $composerCompletePackage->setPhpExt(['download-url-method' => 'composer-default']);
+
+        $package = Package::fromComposerCompletePackage($composerCompletePackage);
+
+        self::assertSame(DownloadUrlMethod::ComposerDefaultDownload, $package->downloadUrlMethod());
+    }
+
+    public function testDownloadUrlMethodWithSingleItemListHasValidDownloadUrlMethod(): void
+    {
+        $composerCompletePackage = new CompletePackage('vendor/foo', '1.2.3.0', '1.2.3');
+        $composerCompletePackage->setPhpExt(['download-url-method' => ['composer-default']]);
+
+        $package = Package::fromComposerCompletePackage($composerCompletePackage);
+
+        self::assertSame(DownloadUrlMethod::ComposerDefaultDownload, $package->downloadUrlMethod());
+    }
+
+    public function testDownloadUrlMethodWithMultiItemListIsNotYetSupported(): void
+    {
+        $composerCompletePackage = new CompletePackage('vendor/foo', '1.2.3.0', '1.2.3');
+        $composerCompletePackage->setPhpExt(['download-url-method' => ['pre-packaged-source', 'composer-default']]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('This extension requires a newer version of PIE. Multiple download-url-methods are not supported until PIE 1.4.0.');
+        Package::fromComposerCompletePackage($composerCompletePackage);
     }
 }


### PR DESCRIPTION
Since we're planning to allow `download-url-method` to be a list (see #436), this change will allow forward-compatibility with that (otherwise a package that starts to use an array, will crash). This PR pre-empts that (although ideally people should upgrade to 1.4.0 anyway :grin:)