### PR TITLE
539: Add bsn4/grpc as PIE-supported alternative for ext-grpc

### DIFF
--- a/docs/supported-extensions.md
+++ b/docs/supported-extensions.md
@@ -51,6 +51,7 @@ The following extensions have already added support for PIE:
 | geospatial     | [php-geospatial/geospatial](https://packagist.org/packages/php-geospatial/geospatial)               |
 | gettext        | php/gettext                                                                                         |
 | gmp            | php/gmp                                                                                             |
+| gRPC           | [bsn4/grpc](https://packagist.org/packages/bsn4/grpc) *(drop-in Rust replacement for ext-grpc)*    |
 | gpio           | [embedded-php/gpio](https://packagist.org/packages/embedded-php/gpio)                               |
 | i2c            | [embedded-php/i2c](https://packagist.org/packages/embedded-php/i2c)                                 |
 | iconv          | php/iconv                                                                                           |
@@ -182,7 +183,6 @@ The following extensions exist on PECL, but either have not added support for PI
 * gmagick
 * gnupg
 * graphdat
-* gRPC
 * handlebars
 * hprose
 * http_message


### PR DESCRIPTION
Moves gRPC from "Not started / Unknown" to "Supported" with [bsn4/grpc](https://packagist.org/packages/bsn4/grpc) — a drop-in Rust replacement for ext-grpc with pre-built binaries for PHP 8.2–8.5 (NTS + ZTS).

Closes #539