### PR TITLE
Allow distribution of musl + glibc binaries

### DIFF
--- a/src/Platform/PrePackagedBinaryAssetName.php
+++ b/src/Platform/PrePackagedBinaryAssetName.php
@@ -21,10 +21,10 @@ final class PrePackagedBinaryAssetName
     /** @return non-empty-list<non-empty-string> */
     public static function packageNames(TargetPlatform $targetPlatform, Package $package): array
     {
-        $debug = $targetPlatform->phpBinaryPath->debugMode() === DebugBuild::Debug ? '-debug' : '';
-        $tsNoSuffix = $targetPlatform->threadSafety === ThreadSafetyMode::ThreadSafe ? '-zts' : '';
+        $debug        = $targetPlatform->phpBinaryPath->debugMode() === DebugBuild::Debug ? '-debug' : '';
+        $tsNoSuffix   = $targetPlatform->threadSafety === ThreadSafetyMode::ThreadSafe ? '-zts' : '';
         $tsWithSuffix = $targetPlatform->threadSafety === ThreadSafetyMode::ThreadSafe ? '-zts' : '-nts';
-        $libc = $targetPlatform->libcFlavour()->value;
+        $libc         = $targetPlatform->libcFlavour()->value;
 
         $name    = $package->extensionName()->name();
         $version = $package->version();

--- a/src/Platform/PrePackagedBinaryAssetName.php
+++ b/src/Platform/PrePackagedBinaryAssetName.php
@@ -21,51 +21,32 @@ final class PrePackagedBinaryAssetName
     /** @return non-empty-list<non-empty-string> */
     public static function packageNames(TargetPlatform $targetPlatform, Package $package): array
     {
-        return array_values(array_unique([
-            strtolower(sprintf(
-                'php_%s-%s_php%s-%s-%s-%s%s%s.zip',
-                $package->extensionName()->name(),
-                $package->version(),
-                $targetPlatform->phpBinaryPath->majorMinorVersion(),
-                $targetPlatform->architecture->name,
-                $targetPlatform->operatingSystemFamily->value,
-                $targetPlatform->libcFlavour()->value,
-                $targetPlatform->phpBinaryPath->debugMode() === DebugBuild::Debug ? '-debug' : '',
-                $targetPlatform->threadSafety === ThreadSafetyMode::ThreadSafe ? '-zts' : '',
-            )),
-            strtolower(sprintf(
-                'php_%s-%s_php%s-%s-%s-%s%s%s.tgz',
-                $package->extensionName()->name(),
-                $package->version(),
-                $targetPlatform->phpBinaryPath->majorMinorVersion(),
-                $targetPlatform->architecture->name,
-                $targetPlatform->operatingSystemFamily->value,
-                $targetPlatform->libcFlavour()->value,
-                $targetPlatform->phpBinaryPath->debugMode() === DebugBuild::Debug ? '-debug' : '',
-                $targetPlatform->threadSafety === ThreadSafetyMode::ThreadSafe ? '-zts' : '',
-            )),
-            strtolower(sprintf(
-                'php_%s-%s_php%s-%s-%s-%s%s%s.zip',
-                $package->extensionName()->name(),
-                $package->version(),
-                $targetPlatform->phpBinaryPath->majorMinorVersion(),
-                $targetPlatform->architecture->name,
-                $targetPlatform->operatingSystemFamily->value,
-                $targetPlatform->libcFlavour()->value,
-                $targetPlatform->phpBinaryPath->debugMode() === DebugBuild::Debug ? '-debug' : '',
-                $targetPlatform->threadSafety === ThreadSafetyMode::ThreadSafe ? '-zts' : '-nts',
-            )),
-            strtolower(sprintf(
-                'php_%s-%s_php%s-%s-%s-%s%s%s.tgz',
-                $package->extensionName()->name(),
-                $package->version(),
-                $targetPlatform->phpBinaryPath->majorMinorVersion(),
-                $targetPlatform->architecture->name,
-                $targetPlatform->operatingSystemFamily->value,
-                $targetPlatform->libcFlavour()->value,
-                $targetPlatform->phpBinaryPath->debugMode() === DebugBuild::Debug ? '-debug' : '',
-                $targetPlatform->threadSafety === ThreadSafetyMode::ThreadSafe ? '-zts' : '-nts',
-            )),
-        ]));
+        $debug = $targetPlatform->phpBinaryPath->debugMode() === DebugBuild::Debug ? '-debug' : '';
+        $tsNoSuffix = $targetPlatform->threadSafety === ThreadSafetyMode::ThreadSafe ? '-zts' : '';
+        $tsWithSuffix = $targetPlatform->threadSafety === ThreadSafetyMode::ThreadSafe ? '-zts' : '-nts';
+        $libc = $targetPlatform->libcFlavour()->value;
+
+        $name    = $package->extensionName()->name();
+        $version = $package->version();
+        $phpVer  = $targetPlatform->phpBinaryPath->majorMinorVersion();
+        $arch    = $targetPlatform->architecture->name;
+        $os      = $targetPlatform->operatingSystemFamily->value;
+
+        $names = [
+            strtolower(sprintf('php_%s-%s_php%s-%s-%s-%s%s%s.zip', $name, $version, $phpVer, $arch, $os, $libc, $debug, $tsNoSuffix)),
+            strtolower(sprintf('php_%s-%s_php%s-%s-%s-%s%s%s.tgz', $name, $version, $phpVer, $arch, $os, $libc, $debug, $tsNoSuffix)),
+            strtolower(sprintf('php_%s-%s_php%s-%s-%s-%s%s%s.zip', $name, $version, $phpVer, $arch, $os, $libc, $debug, $tsWithSuffix)),
+            strtolower(sprintf('php_%s-%s_php%s-%s-%s-%s%s%s.tgz', $name, $version, $phpVer, $arch, $os, $libc, $debug, $tsWithSuffix)),
+        ];
+
+        // Fallbacks with anylibc suffix, for unified binaries compatible with both glibc and musl (Linux only)
+        if ($targetPlatform->operatingSystemFamily === OperatingSystemFamily::Linux) {
+            $names[] = strtolower(sprintf('php_%s-%s_php%s-%s-%s-anylibc%s%s.zip', $name, $version, $phpVer, $arch, $os, $debug, $tsNoSuffix));
+            $names[] = strtolower(sprintf('php_%s-%s_php%s-%s-%s-anylibc%s%s.tgz', $name, $version, $phpVer, $arch, $os, $debug, $tsNoSuffix));
+            $names[] = strtolower(sprintf('php_%s-%s_php%s-%s-%s-anylibc%s%s.zip', $name, $version, $phpVer, $arch, $os, $debug, $tsWithSuffix));
+            $names[] = strtolower(sprintf('php_%s-%s_php%s-%s-%s-anylibc%s%s.tgz', $name, $version, $phpVer, $arch, $os, $debug, $tsWithSuffix));
+        }
+
+        return array_values(array_unique($names));
     }
 }

--- a/test/unit/Downloading/DownloadUrlMethodTest.php
+++ b/test/unit/Downloading/DownloadUrlMethodTest.php
@@ -145,10 +145,13 @@ final class DownloadUrlMethodTest extends TestCase
 
         self::assertSame(DownloadUrlMethod::PrePackagedBinary, $downloadUrlMethod);
 
+        // TargetPlatform doesn't have the libc specified, so the assertion needs to be made
+        // against the test machine's libc
+        $libc = $targetPlatform->libcFlavour()->value;
         self::assertSame(
             [
-                'php_bar-1.2.3_php8.3-x86_64-linux-glibc-debug-zts.zip',
-                'php_bar-1.2.3_php8.3-x86_64-linux-glibc-debug-zts.tgz',
+                'php_bar-1.2.3_php8.3-x86_64-linux-' . $libc . '-debug-zts.zip',
+                'php_bar-1.2.3_php8.3-x86_64-linux-' . $libc . '-debug-zts.tgz',
                 'php_bar-1.2.3_php8.3-x86_64-linux-anylibc-debug-zts.zip',
                 'php_bar-1.2.3_php8.3-x86_64-linux-anylibc-debug-zts.tgz',
             ],
@@ -223,12 +226,15 @@ final class DownloadUrlMethodTest extends TestCase
 
         $firstMethod = $downloadUrlMethods[0];
         self::assertSame(DownloadUrlMethod::PrePackagedBinary, $firstMethod);
+        // TargetPlatform doesn't have the libc specified, so the assertion needs to be made
+        // against the test machine's libc
+        $libc = $targetPlatform->libcFlavour()->value;
         self::assertSame(
             [
-                'php_bar-1.2.3_php8.3-x86_64-linux-glibc-debug.zip',
-                'php_bar-1.2.3_php8.3-x86_64-linux-glibc-debug.tgz',
-                'php_bar-1.2.3_php8.3-x86_64-linux-glibc-debug-nts.zip',
-                'php_bar-1.2.3_php8.3-x86_64-linux-glibc-debug-nts.tgz',
+                'php_bar-1.2.3_php8.3-x86_64-linux-' . $libc . '-debug.zip',
+                'php_bar-1.2.3_php8.3-x86_64-linux-' . $libc . '-debug.tgz',
+                'php_bar-1.2.3_php8.3-x86_64-linux-' . $libc . '-debug-nts.zip',
+                'php_bar-1.2.3_php8.3-x86_64-linux-' . $libc . '-debug-nts.tgz',
                 'php_bar-1.2.3_php8.3-x86_64-linux-anylibc-debug.zip',
                 'php_bar-1.2.3_php8.3-x86_64-linux-anylibc-debug.tgz',
                 'php_bar-1.2.3_php8.3-x86_64-linux-anylibc-debug-nts.zip',

--- a/test/unit/Downloading/DownloadUrlMethodTest.php
+++ b/test/unit/Downloading/DownloadUrlMethodTest.php
@@ -149,6 +149,8 @@ final class DownloadUrlMethodTest extends TestCase
             [
                 'php_bar-1.2.3_php8.3-x86_64-linux-glibc-debug-zts.zip',
                 'php_bar-1.2.3_php8.3-x86_64-linux-glibc-debug-zts.tgz',
+                'php_bar-1.2.3_php8.3-x86_64-linux-anylibc-debug-zts.zip',
+                'php_bar-1.2.3_php8.3-x86_64-linux-anylibc-debug-zts.tgz',
             ],
             $downloadUrlMethod->possibleAssetNames($package, $targetPlatform),
         );
@@ -227,6 +229,10 @@ final class DownloadUrlMethodTest extends TestCase
                 'php_bar-1.2.3_php8.3-x86_64-linux-glibc-debug.tgz',
                 'php_bar-1.2.3_php8.3-x86_64-linux-glibc-debug-nts.zip',
                 'php_bar-1.2.3_php8.3-x86_64-linux-glibc-debug-nts.tgz',
+                'php_bar-1.2.3_php8.3-x86_64-linux-anylibc-debug.zip',
+                'php_bar-1.2.3_php8.3-x86_64-linux-anylibc-debug.tgz',
+                'php_bar-1.2.3_php8.3-x86_64-linux-anylibc-debug-nts.zip',
+                'php_bar-1.2.3_php8.3-x86_64-linux-anylibc-debug-nts.tgz',
             ],
             $firstMethod->possibleAssetNames($package, $targetPlatform),
         );

--- a/test/unit/Platform/PrePackagedBinaryAssetNameTest.php
+++ b/test/unit/Platform/PrePackagedBinaryAssetNameTest.php
@@ -46,6 +46,10 @@ final class PrePackagedBinaryAssetNameTest extends TestCase
                 'php_foobar-1.2.3_php8.2-x86_64-linux-' . $libc->value . '.tgz',
                 'php_foobar-1.2.3_php8.2-x86_64-linux-' . $libc->value . '-nts.zip',
                 'php_foobar-1.2.3_php8.2-x86_64-linux-' . $libc->value . '-nts.tgz',
+                'php_foobar-1.2.3_php8.2-x86_64-linux-anylibc.zip',
+                'php_foobar-1.2.3_php8.2-x86_64-linux-anylibc.tgz',
+                'php_foobar-1.2.3_php8.2-x86_64-linux-anylibc-nts.zip',
+                'php_foobar-1.2.3_php8.2-x86_64-linux-anylibc-nts.tgz',
             ],
             PrePackagedBinaryAssetName::packageNames(
                 $targetPlatform,
@@ -83,6 +87,8 @@ final class PrePackagedBinaryAssetNameTest extends TestCase
             [
                 'php_foobar-1.2.3_php8.3-x86_64-linux-' . $libc->value . '-zts.zip',
                 'php_foobar-1.2.3_php8.3-x86_64-linux-' . $libc->value . '-zts.tgz',
+                'php_foobar-1.2.3_php8.3-x86_64-linux-anylibc-zts.zip',
+                'php_foobar-1.2.3_php8.3-x86_64-linux-anylibc-zts.tgz',
             ],
             PrePackagedBinaryAssetName::packageNames(
                 $targetPlatform,


### PR DESCRIPTION
Search for binaries with the `anylibc` suffix as a fallback candidate (on Linux only).

This allows shipping binaries that work both on glibc and musl without copying the same binary with two separate names.

The second commit fixes assertion failures when not running a linux/glibc (I think a better long-term solution would be to extend `TargetPlatform` to also take the libc flavor.

Fixes #544 

## PR submitter checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I discussed this feature with the maintainers in #544
- [x] I have added appropriate tests
- [x] I confirm that I have the right to submit this under the project's open source licence
