### PR TITLE
Improve Docker instructions in docs/usage.md

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -33,10 +33,11 @@ curl -fL --output /tmp/pie.phar https://github.com/php/pie/releases/latest/downl
 
 ### Docker installation
 
-PIE is published as binary-only Docker image, so you can install it easily during your Docker build:
+PIE is published as binary-only Docker image, so you can use it easily during your Docker build:
 
 ```Dockerfile
-COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie \
+    pie -V
 ```
 
 Instead of `bin` tag (which represents latest binary-only image) you can also use explicit version (in `x.y.z-bin` format). Use [GitHub registry](https://ghcr.io/php/pie) to find available tags.
@@ -54,17 +55,20 @@ installed.
 ```Dockerfile
 FROM php:8.4-cli
 
-# Add the `unzip` package which PIE uses to extract .zip files
-RUN export DEBIAN_FRONTEND="noninteractive"; \
+RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie \
+    export DEBIAN_FRONTEND="noninteractive"; \
     set -eux; \
-    apt-get update; apt-get install -y --no-install-recommends unzip; \
-    rm -rf /var/lib/apt/lists/*
+    # Add the `unzip` package which PIE uses to extract .zip files.
+    apt-get update; \
+    apt-get install -y --no-install-recommends unzip; \
+    # Use PIE to install an extension...
+    pie install asgrim/example-pie-extension; \
+    # Clean up `unzip`.
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false unzip; \
+    rm -rf /var/lib/apt/lists/*;
 
-# Copy the pie.phar from the latest `:bin` release
-COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
 
-# Use PIE to install an extension...
-RUN pie install asgrim/example-pie-extension
+CMD ["php", "-r", "example_pie_extension_test();"]
 ```
 
 If the extension you would like to install needs additional libraries or other


### PR DESCRIPTION
This aims to strike a balance between “best practice” and “being easy to understand”. It uses `RUN --mount` to avoid including PIE in the resulting image and takes care to uninstall `unzip` as well, but does not provide “extension mechanisms” to install per-extension build or runtime libraries.

------------

The “long example” is now self-contained including a demo `CMD`:

```
$ docker build -t test .
[+] Building 0.2s (8/8) FINISHED                                                                                                                                                                                                                                                                                                                                              docker:rootless
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                                                                                                     0.0s
 => => transferring dockerfile: 641B                                                                                                                                                                                                                                                                                                                                                     0.0s
 => [internal] load metadata for ghcr.io/php/pie:bin                                                                                                                                                                                                                                                                                                                                     0.2s
 => [internal] load metadata for docker.io/library/php:8.4-cli                                                                                                                                                                                                                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                                                                                        0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                                                                                                                                          0.0s
 => FROM ghcr.io/php/pie:bin@sha256:24df295bb3dbf6cbcb42f49a14eaef043b99ccaa17f8412f3c04eb330e6da12d                                                                                                                                                                                                                                                                                     0.0s
 => [stage-0 1/2] FROM docker.io/library/php:8.4-cli                                                                                                                                                                                                                                                                                                                                     0.0s
 => CACHED [stage-0 2/2] RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie     export DEBIAN_FRONTEND="noninteractive";     set -eux;     apt-get update;     apt-get install -y --no-install-recommends unzip;     pie install asgrim/example-pie-extension;     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false unzip  0.0s
 => exporting to image                                                                                                                                                                                                                                                                                                                                                                   0.0s
 => => exporting layers                                                                                                                                                                                                                                                                                                                                                                  0.0s
 => => writing image sha256:d8b2494ffd6f830fcb6fde1ca9cd511fac7c6d52f5b9dae92f6fe26fd8e37306                                                                                                                                                                                                                                                                                             0.0s
 => => naming to docker.io/library/test                                                                                                                                                                                                                                                                                                                                                  0.0s
$ docker run -it --rm test
Hello, world!
```

It comes with just 1.4 MB of additional storage requirements (not the full 11 MB of PIE):

```
$ docker history test 
IMAGE          CREATED         CREATED BY                                      SIZE      COMMENT
d8b2494ffd6f   6 minutes ago   CMD ["php" "-r" "example_pie_extension_test(…   0B        buildkit.dockerfile.v0
<missing>      6 minutes ago   RUN /bin/sh -c export DEBIAN_FRONTEND="nonin…   1.41MB    buildkit.dockerfile.v0
```

## PR submitter checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I discussed this <bug|feature> with the maintainers in #<issue_number> (complete as appropriate)
- [x] I have added appropriate tests
- [x] I confirm that I have the right to submit this under the project's open source licence
