### PR TITLE
Add `--no-cache` to Docker instructions

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -62,11 +62,11 @@ RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin
     apt-get update; \
     apt-get install -y --no-install-recommends unzip; \
     # Use PIE to install an extension...
-    pie install asgrim/example-pie-extension; \
+    pie install --no-cache \
+        asgrim/example-pie-extension; \
     # Clean up `unzip`.
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false unzip; \
     rm -rf /var/lib/apt/lists/*;
-
 
 CMD ["php", "-r", "example_pie_extension_test();"]
 ```


### PR DESCRIPTION
The composer cache is not reusable within Docker, as each build is independent. It thus just bloats the final image.

## PR submitter checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I discussed this <bug|feature> with the maintainers in #<issue_number> (complete as appropriate)
- [x] I have added appropriate tests
- [x] I confirm that I have the right to submit this under the project's open source licence
