### PR TITLE
537: fix deprecated output when using Box

### DIFF
--- a/box.json.dist
+++ b/box.json.dist
@@ -2,6 +2,7 @@
     "alias": "pie.phar",
     "output": "pie.phar",
     "git": "pie_version",
+    "stub": "phar-stub.php",
     "force-autodiscovery": true,
     "directories": [
         "resources"

--- a/phar-stub.php
+++ b/phar-stub.php
@@ -1,0 +1,19 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+// echo "James says hello :)\n";
+
+// Workaround for https://github.com/php/pie/issues/537 and https://github.com/box-project/box/issues/1577
+error_reporting(error_reporting() & ~E_DEPRECATED);
+
+Phar::mapPhar('pie.phar');
+
+require 'phar://pie.phar/.box/bin/check-requirements.php';
+
+$_SERVER['SCRIPT_FILENAME'] = 'phar://pie.phar/bin/pie';
+require 'phar://pie.phar/bin/pie';
+
+// phpcs:ignore Generic.Files.InlineHTML.Found
+__HALT_COMPILER(); ?>


### PR DESCRIPTION
Fixes #537 

 - PIE issue: https://github.com/php/pie/issues/537
 - Upstream box issue: https://github.com/box-project/box/issues/1577

Can probably be reverted once the Box issue is fixed & released

## PR submitter checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I discussed this bug with the maintainers in #537
- [x] I have added appropriate tests
- [x] I confirm that I have the right to submit this under the project's open source licence
