### PR TITLE
557: use suffix directive for Docker tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,4 +93,4 @@ jobs:
       # @see https://github.com/php/pie/pull/122#discussion_r1867331273
       tags: |
         ${{ ((!contains(github.ref, 'alpha') && !contains(github.ref, 'beta') && !contains(github.ref, 'rc')) && 'type=raw,value=bin') || '' }}
-        type=semver,pattern={{version}}-bin
+        type=semver,pattern={{version}},suffix=-bin


### PR DESCRIPTION
Fixes #557 

## PR submitter checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I discussed this bug with the maintainers in #557 
- [x] I have added appropriate tests
- [x] I confirm that I have the right to submit this under the project's open source licence
