### PR TITLE
590: prevent pre-packaged-binary from being used when configure options are passed

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -313,6 +313,11 @@ pie install example/some-extension --with-some-library-name=/path/to/the/lib
 pie install example/some-extension --with-some-library-name=/path/to/the/lib --enable-some-functionality
 ```
 
+> [!TIP]
+> If you specify configure options for a package that uses the
+> `pre-packaged-binary` download method, PIE will fall back to compiling the
+> extension using the configure options you have specified.
+
 ### Build tools check
 
 PIE will attempt to check the presence of build tools (such as gcc, make, etc.)

--- a/src/ComposerIntegration/Listeners/OverrideDownloadUrlInstallListener.php
+++ b/src/ComposerIntegration/Listeners/OverrideDownloadUrlInstallListener.php
@@ -80,6 +80,15 @@ class OverrideDownloadUrlInstallListener
                 foreach ($downloadUrlMethods as $downloadUrlMethod) {
                     $this->io->write('Trying to download using: ' . $downloadUrlMethod->value, verbosity: IOInterface::VERY_VERBOSE);
 
+                    if ($downloadUrlMethod === DownloadUrlMethod::PrePackagedBinary && $this->composerRequest->configureOptions !== []) {
+                        $configureOptionsConflictMessage = 'Cannot use pre-packaged-binary download method, as configure options were passed.';
+
+                        $downloadMethodFailures[$downloadUrlMethod->value] = $configureOptionsConflictMessage;
+                        $this->io->write($configureOptionsConflictMessage, verbosity: IOInterface::VERBOSE);
+
+                        continue;
+                    }
+
                     // Exit early if we should just use Composer's normal download
                     if ($downloadUrlMethod === DownloadUrlMethod::ComposerDefaultDownload) {
                         $selectedDownloadUrlMethod = $downloadUrlMethod;

--- a/test/unit/ComposerIntegration/Listeners/OverrideDownloadUrlInstallListenerTest.php
+++ b/test/unit/ComposerIntegration/Listeners/OverrideDownloadUrlInstallListenerTest.php
@@ -500,6 +500,57 @@ final class OverrideDownloadUrlInstallListenerTest extends TestCase
         self::assertSame('zip', $composerPackage->getDistType());
     }
 
+    public function testPrePackagedBinaryMethodIsIgnoredWhenConfigureOptionsArePassed(): void
+    {
+        $composerPackage = new CompletePackage('foo/bar', '1.2.3.0', '1.2.3');
+        $composerPackage->setDistType('zip');
+        $composerPackage->setDistUrl('https://example.com/git-archive-zip-url');
+        $composerPackage->setPhpExt([
+            'extension-name' => 'foobar',
+            'download-url-method' => ['pre-packaged-binary'],
+        ]);
+
+        $installerEvent = new InstallerEvent(
+            InstallerEvents::PRE_OPERATIONS_EXEC,
+            $this->composer,
+            $this->io,
+            false,
+            true,
+            new Transaction([], [$composerPackage]),
+        );
+
+        $this->container
+            ->expects(self::never())
+            ->method('get');
+
+        $listener = new OverrideDownloadUrlInstallListener(
+            $this->composer,
+            $this->io,
+            $this->container,
+            new PieComposerRequest(
+                $this->createMock(IOInterface::class),
+                new TargetPlatform(
+                    OperatingSystem::NonWindows,
+                    OperatingSystemFamily::Linux,
+                    PhpBinaryPath::fromCurrentProcess(),
+                    Architecture::x86_64,
+                    ThreadSafetyMode::NonThreadSafe,
+                    1,
+                    WindowsCompiler::VC15,
+                    null,
+                ),
+                new RequestedPackageAndVersion('foo/bar', '^1.1'),
+                PieOperation::Install,
+                ['--with-foo'],
+                false,
+            ),
+        );
+
+        $this->expectException(CouldNotDetermineDownloadUrlMethod::class);
+        $this->expectExceptionMessage('Could not download foo/bar using pre-packaged-binary method: Cannot use pre-packaged-binary download method, as configure options were passed.');
+        $listener($installerEvent);
+    }
+
     public function testNoSelectedDownloadUrlMethodWillThrowException(): void
     {
         $composerPackage = new CompletePackage('foo/bar', '1.2.3.0', '1.2.3');


### PR DESCRIPTION
Fixes #590 

## PR submitter checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I discussed this bug with the maintainers in #590 
- [x] I have added appropriate tests
- [x] I confirm that I have the right to submit this under the project's open source licence
