### PR TITLE
597: don't auto install re2c and bison

### DIFF
--- a/src/SelfManage/BuildTools/CheckAllBuildTools.php
+++ b/src/SelfManage/BuildTools/CheckAllBuildTools.php
@@ -51,26 +51,6 @@ class CheckAllBuildTools
                 ],
             ),
             new BinaryBuildToolFinder(
-                'bison',
-                [
-                    PackageManager::Apt->value => 'bison',
-                    PackageManager::Apk->value => 'bison',
-                    PackageManager::Dnf->value => 'bison',
-                    PackageManager::Yum->value => 'bison',
-                    PackageManager::Brew->value => 'bison',
-                ],
-            ),
-            new BinaryBuildToolFinder(
-                're2c',
-                [
-                    PackageManager::Apt->value => 're2c',
-                    PackageManager::Apk->value => 're2c',
-                    PackageManager::Dnf->value => 're2c',
-                    PackageManager::Yum->value => 're2c',
-                    PackageManager::Brew->value => 're2c',
-                ],
-            ),
-            new BinaryBuildToolFinder(
                 'pkg-config',
                 [
                     PackageManager::Apt->value => 'pkg-config',


### PR DESCRIPTION
Part of #597 - remove re2c and bison from the install list

## PR submitter checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I discussed this bug with the maintainers in #597 
- [x] I have added appropriate tests
- [x] I confirm that I have the right to submit this under the project's open source licence
