### PR TITLE
Add granular publish tags for "-bin" docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,9 +88,8 @@ jobs:
       packages: write
     uses: ./.github/workflows/build-and-push-docker-image.yml
     with:
-      # @TODO v1.0 Consider introducing more granular tags (major and major.minor)
-      # @see https://github.com/php/pie/pull/122#pullrequestreview-2477496308
-      # @see https://github.com/php/pie/pull/122#discussion_r1867331273
       tags: |
         ${{ ((!contains(github.ref, 'alpha') && !contains(github.ref, 'beta') && !contains(github.ref, 'rc')) && 'type=raw,value=bin') || '' }}
         type=semver,pattern={{version}},suffix=-bin
+        type=semver,pattern={{major}}.{{minor}},suffix=bin
+        type=semver,pattern={{major}},suffix=bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,5 +91,5 @@ jobs:
       tags: |
         ${{ ((!contains(github.ref, 'alpha') && !contains(github.ref, 'beta') && !contains(github.ref, 'rc')) && 'type=raw,value=bin') || '' }}
         type=semver,pattern={{version}},suffix=-bin
-        type=semver,pattern={{major}}.{{minor}},suffix=bin
-        type=semver,pattern={{major}},suffix=bin
+        type=semver,pattern={{major}}.{{minor}},suffix=-bin
+        type=semver,pattern={{major}},suffix=-bin


### PR DESCRIPTION
Implement TODO:
- https://github.com/php/pie/blob/5c3fa89c5f63728f60fda04756b4044c01855ff7/.github/workflows/release.yml#L90-L96

See:
- https://github.com/php/pie/pull/122#pullrequestreview-2477496308
- https://github.com/php/pie/pull/122#discussion_r1867331273
- https://github.com/php/pie/issues/480

<!--- IMPORTANT - READ BEFORE SUBMITTING YOUR PR -->
<!--- If you have not discussed this change with us this change before -->
<!--- submitting a Pull Request, you may be duplicating work already in -->
<!--- progress. Please either open an issue (for bugs), or create a -->
<!--- discussion (for features), and discuss the change BEFORE working -->
<!--- on it, so you are not wasting your time... -->

## PR submitter checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/php/pie/blob/HEAD/CONTRIBUTING.md)
- [x] I discussed this feature with the maintainers in https://github.com/php/pie/pull/122
- [x] <del>I have added appropriate tests</del>
- [x] I confirm that I have the right to submit this under the project's open source licence


## Future TODO

After this is merged and verified working also update documentation (another PR):
- https://github.com/php/pie/blob/1.5.x/docs/usage.md#docker-installation