### PR TITLE
Add unzip to required build tools

### DIFF
--- a/src/SelfManage/BuildTools/CheckAllBuildTools.php
+++ b/src/SelfManage/BuildTools/CheckAllBuildTools.php
@@ -70,6 +70,25 @@ class CheckAllBuildTools
                     PackageManager::Brew->value => 'libtool',
                 ],
             ),
+            // Composer's archive downloader uses /usr/bin/unzip first
+            // and falls back to git-source-cloning when it isn't
+            // present (not to PHP's ZipArchive). Without unzip, a
+            // pre-packaged-binary dist URL is silently swapped for a
+            // git clone of the source tree and the .so the user paid
+            // for in download time is never extracted, surfacing as
+            // ExtensionBinaryNotFound when PIE's prePackagedBinary
+            // check looks for it in the vendor dir. Bare php:X.Y-cli
+            // Debian images do not ship /usr/bin/unzip.
+            new BinaryBuildToolFinder(
+                'unzip',
+                [
+                    PackageManager::Apt->value => 'unzip',
+                    PackageManager::Apk->value => 'unzip',
+                    PackageManager::Dnf->value => 'unzip',
+                    PackageManager::Yum->value => 'unzip',
+                    PackageManager::Brew->value => 'unzip',
+                ],
+            ),
             new PhpizeBuildToolFinder(
                 [
                     PackageManager::Apt->value => 'php-dev',


### PR DESCRIPTION
When an extension declares `download-url-method: ["pre-packaged-binary", ...]`, PIE calls `setDistUrl(zip-url)` so composer downloads and extracts the .so into the vendor dir. composer's archive downloader probes for `/usr/bin/unzip` first. When it isn't present, composer doesn't fall back to PHP's ZipArchive; it falls back to git-cloning the source. The prebuilt dist is silently discarded, the .so never lands in the vendor dir, and `UnixBuild::prePackagedBinary` trips `ExtensionBinaryNotFound` looking for it.

`php:X.Y-cli` Debian images don't ship `/usr/bin/unzip`, so this hits any `pie install <pkg>` on a minimal container when the extension publishes prebuilt binaries. Repro:

```sh
docker run --rm php:8.4-cli sh -c '
    apt-get update -qq
    apt-get install -y -qq curl git ca-certificates  # no unzip
    curl -sSL https://github.com/php/pie/releases/download/1.4.4/pie.phar \
        -o /usr/local/bin/pie && chmod +x /usr/local/bin/pie
    pie install --with-php-config=/usr/local/bin/php-config \
        --auto-install-build-tools iliaal/fastchart'
```

The patch adds `unzip` to `CheckAllBuildTools::buildToolsFactory()` alongside the existing tools. Package name is `unzip` on apt/apk/dnf/yum/brew. With `--auto-install-build-tools`, PIE installs it and the prebuilt-binary lane works.

Caught while releasing iliaal/fastchart 1.1.1.