### PR TITLE
Fix: Skip semver tag patterns for pre-releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,5 +91,5 @@ jobs:
       tags: |
         ${{ ((!contains(github.ref, 'alpha') && !contains(github.ref, 'beta') && !contains(github.ref, 'rc')) && 'type=raw,value=bin') || '' }}
         type=semver,pattern={{version}},suffix=-bin
-        type=semver,pattern={{major}}.{{minor}},suffix=-bin
-        type=semver,pattern={{major}},suffix=-bin
+        ${{ ((!contains(github.ref, 'alpha') && !contains(github.ref, 'beta') && !contains(github.ref, 'rc')) && 'type=semver,pattern={{major}}.{{minor}},suffix=-bin') || '' }}
+        ${{ ((!contains(github.ref, 'alpha') && !contains(github.ref, 'beta') && !contains(github.ref, 'rc')) && 'type=semver,pattern={{major}},suffix=-bin') || '' }}


### PR DESCRIPTION
Fixes #480 

## PR submitter checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/php/pie/blob/HEAD/CONTRIBUTING.md)
- [x] I discussed this bug with the maintainers in https://github.com/php/pie/pull/614
- [ ] ~~I have added appropriate tests~~
- [x] I confirm that I have the right to submit this under the project's open source licence
