### PR TITLE
622: use providers API to find matching exts in pie install for PHP projects

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -169,9 +169,9 @@ parameters:
 			path: src/File/WindowsDelete.php
 
 		-
-			message: '#^Call to function array_key_exists\(\) with ''downloads'' and array\{name\: string, description\: string\|null, abandoned\?\: string\|true, url\?\: string\} will always evaluate to false\.$#'
-			identifier: function.impossibleType
-			count: 2
+			message: '#^Call to static method Php\\Pie\\ExtensionName\:\:isValidExtensionName\(\) with non\-empty\-string will always evaluate to true\.$#'
+			identifier: staticMethod.alreadyNarrowedType
+			count: 1
 			path: src/Installing/InstallForPhpProject/FindMatchingPackages.php
 
 		-

--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -36,6 +36,7 @@ use Webmozart\Assert\Assert;
 
 use function array_key_exists;
 use function array_map;
+use function assert;
 use function count;
 use function is_array;
 use function is_string;
@@ -430,6 +431,8 @@ final class CommandHelper
             $requestedPackageName = substr($requestedPackageName, 4);
         }
 
+        assert($requestedPackageName !== '');
+
         $io->writeError('');
         $io->writeError(sprintf('<error>Could not install package: %s</error>', $requestedPackageName));
         $io->writeError($exception->getMessage());
@@ -460,7 +463,7 @@ final class CommandHelper
 
                     return $match;
                 },
-                $findMatchingPackages->for($pieComposer, $requestedPackageName),
+                $findMatchingPackages->bySearching($pieComposer, $requestedPackageName),
             );
 
             if (count($matches)) {

--- a/src/Command/InstallExtensionsForProjectCommand.php
+++ b/src/Command/InstallExtensionsForProjectCommand.php
@@ -225,7 +225,7 @@ final class InstallExtensionsForProjectCommand extends Command
                 ));
 
                 try {
-                    $matches = $this->findMatchingPackages->for($pieComposer, $extension->name());
+                    $matches = $this->findMatchingPackages->byProvider($pieComposer, $extension);
                 } catch (OutOfRangeException) {
                     $anyErrorsHappened = true;
 

--- a/src/Installing/InstallForPhpProject/FindMatchingPackages.php
+++ b/src/Installing/InstallForPhpProject/FindMatchingPackages.php
@@ -10,10 +10,12 @@ use Composer\Repository\RepositoryInterface;
 use OutOfRangeException;
 use Php\Pie\DependencyResolver\Package;
 use Php\Pie\ExtensionName;
+use Php\Pie\ExtensionType;
 
 use function array_filter;
 use function array_key_exists;
 use function array_merge;
+use function array_values;
 use function count;
 use function usort;
 
@@ -24,15 +26,14 @@ use function usort;
  */
 class FindMatchingPackages
 {
-    /** @return MatchingPackages */
-    public function for(Composer $pieComposer, string $searchTerm): array
+    /**
+     * @param list<array{name: string, description: ?string, downloads?: int}> $matches
+     * @param non-empty-string                                                 $searchTerm
+     *
+     * @return MatchingPackages
+     */
+    private function filterToCompatible(Composer $pieComposer, array $matches, string $searchTerm): array
     {
-        $matches = [];
-        foreach ($pieComposer->getRepositoryManager()->getRepositories() as $repo) {
-            $matches = array_merge($matches, $repo->search($searchTerm, RepositoryInterface::SEARCH_FULLTEXT, 'php-ext'));
-            $matches = array_merge($matches, $repo->search($searchTerm, RepositoryInterface::SEARCH_FULLTEXT, 'php-ext-zend'));
-        }
-
         if (ExtensionName::isValidExtensionName($searchTerm)) {
             $extensionName = ExtensionName::normaliseFromString($searchTerm);
 
@@ -41,7 +42,7 @@ class FindMatchingPackages
                 static function (array $match) use ($pieComposer, $extensionName): bool {
                     $package = $pieComposer->getRepositoryManager()->findPackage($match['name'], '*');
 
-                    if (! $package instanceof CompletePackageInterface) {
+                    if (! $package instanceof CompletePackageInterface || ! ExtensionType::isValid($package->getType())) {
                         return false;
                     }
 
@@ -60,5 +61,32 @@ class FindMatchingPackages
         });
 
         return $matches;
+    }
+
+    /** @return MatchingPackages */
+    public function byProvider(Composer $pieComposer, ExtensionName $extensionName): array
+    {
+        $matches = [];
+        foreach ($pieComposer->getRepositoryManager()->getRepositories() as $repo) {
+            $matches = array_merge($matches, $repo->getProviders($extensionName->nameWithExtPrefix()));
+        }
+
+        return $this->filterToCompatible($pieComposer, array_values($matches), $extensionName->name());
+    }
+
+    /**
+     * @param non-empty-string $searchTerm
+     *
+     * @return MatchingPackages
+     */
+    public function bySearching(Composer $pieComposer, string $searchTerm): array
+    {
+        $matches = [];
+        foreach ($pieComposer->getRepositoryManager()->getRepositories() as $repo) {
+            $matches = array_merge($matches, $repo->search($searchTerm, RepositoryInterface::SEARCH_FULLTEXT, 'php-ext'));
+            $matches = array_merge($matches, $repo->search($searchTerm, RepositoryInterface::SEARCH_FULLTEXT, 'php-ext-zend'));
+        }
+
+        return $this->filterToCompatible($pieComposer, $matches, $searchTerm);
     }
 }

--- a/test/integration/Command/InstallExtensionsForProjectCommandTest.php
+++ b/test/integration/Command/InstallExtensionsForProjectCommandTest.php
@@ -119,7 +119,7 @@ final class InstallExtensionsForProjectCommandTest extends TestCase
 
         $this->composerFactoryForProject->method('composer')->willReturn($composer);
 
-        $this->findMatchingPackages->method('for')->willReturn([
+        $this->findMatchingPackages->method('byProvider')->willReturn([
             ['name' => 'vendor1/foobar', 'description' => 'The official foobar implementation'],
         ]);
 
@@ -175,7 +175,7 @@ final class InstallExtensionsForProjectCommandTest extends TestCase
 
         $this->composerFactoryForProject->method('composer')->willReturn($composer);
 
-        $this->findMatchingPackages->method('for')->willReturn([
+        $this->findMatchingPackages->method('byProvider')->willReturn([
             ['name' => 'vendor1/foobar', 'description' => 'The official foobar implementation'],
             ['name' => 'vendor2/afoobar', 'description' => 'An improved async foobar extension'],
         ]);

--- a/test/unit/Installing/InstallForPhpProject/FindMatchingPackagesTest.php
+++ b/test/unit/Installing/InstallForPhpProject/FindMatchingPackagesTest.php
@@ -12,6 +12,7 @@ use Composer\Package\CompletePackageInterface;
 use Composer\Repository\ArrayRepository;
 use Composer\Repository\RepositoryManager;
 use Composer\Util\HttpDownloader;
+use Php\Pie\ExtensionName;
 use Php\Pie\ExtensionType;
 use Php\Pie\Installing\InstallForPhpProject\FindMatchingPackages;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -67,6 +68,54 @@ final class FindMatchingPackagesTest extends TestCase
                 ],
             ],
             (new FindMatchingPackages())->bySearching($composer, 'bar'),
+        );
+    }
+
+    public function testByProvider(): void
+    {
+        $package = new CompletePackage('foo/bar', '2.0.0.0', '2.0.0');
+        $package->setDescription('The best extension there is');
+        $package->setType(ExtensionType::PhpModule->value);
+
+        $repository = $this->createPartialMock(ArrayRepository::class, ['getProviders']);
+        $repository->addPackage($package);
+        $repository->expects(self::once())
+            ->method('getProviders')
+            ->with('ext-bar')
+            ->willReturn([
+                'foo1/bar' => [
+                    'name' => 'foo1/bar',
+                    'description' => 'This is foo1/bar, not quite what you are looking for',
+                    'type' => 'library',
+                ],
+                'foo/bar' => [
+                    'name' => 'foo/bar',
+                    'description' => 'The best extension there is',
+                    'type' => 'php-ext',
+                ],
+            ]);
+
+        $repoManager = new RepositoryManager(
+            $this->createMock(IOInterface::class),
+            $this->createMock(Config::class),
+            $this->createMock(HttpDownloader::class),
+            null,
+            null,
+        );
+        $repoManager->addRepository($repository);
+
+        $composer = $this->createMock(Composer::class);
+        $composer->method('getRepositoryManager')->willReturn($repoManager);
+
+        self::assertSame(
+            [
+                [
+                    'name' => 'foo/bar',
+                    'description' => 'The best extension there is',
+                    'type' => 'php-ext',
+                ],
+            ],
+            (new FindMatchingPackages())->byProvider($composer, ExtensionName::normaliseFromString('bar')),
         );
     }
 }

--- a/test/unit/Installing/InstallForPhpProject/FindMatchingPackagesTest.php
+++ b/test/unit/Installing/InstallForPhpProject/FindMatchingPackagesTest.php
@@ -66,7 +66,7 @@ final class FindMatchingPackagesTest extends TestCase
                     'description' => 'The best extension there is',
                 ],
             ],
-            (new FindMatchingPackages())->for($composer, 'bar'),
+            (new FindMatchingPackages())->bySearching($composer, 'bar'),
         );
     }
 }


### PR DESCRIPTION
Fixes #622 

## PR submitter checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/php/pie/blob/HEAD/CONTRIBUTING.md)
- [x] I discussed this feature with the maintainers in #622 
- [x] I have added appropriate tests
- [x] I confirm that I have the right to submit this under the project's open source licence
