### PR TITLE
Warn when target PHP version does not match project requirement

### DIFF
--- a/src/Command/InstallExtensionsForProjectCommand.php
+++ b/src/Command/InstallExtensionsForProjectCommand.php
@@ -22,6 +22,7 @@ use Php\Pie\Installing\InstallForPhpProject\InstallPiePackageFromPath;
 use Php\Pie\Installing\InstallForPhpProject\InstallSelectedPackage;
 use Php\Pie\Platform;
 use Php\Pie\Platform\InstalledPiePackages;
+use Php\Pie\Platform\TargetPlatform;
 use Php\Pie\Util\Emoji;
 use Psr\Container\ContainerInterface;
 use Safe\Exceptions\DirException;
@@ -103,6 +104,8 @@ final class InstallExtensionsForProjectCommand extends Command
         CommandHelper::applyNoCacheOptionIfSet($input, $this->io);
 
         $rootPackage = $this->composerFactoryForProject->rootPackage($this->io);
+        $targetPlatform = CommandHelper::determineTargetPlatformFromInputs($input, $this->io);
+        self::warnIfTargetPhpDoesNotSatisfyComposerRequirement($rootPackage->getRequires()['php'] ?? null, $targetPlatform, $this->io);
 
         if (ExtensionType::isValid($rootPackage->getType())) {
             try {
@@ -122,7 +125,7 @@ final class InstallExtensionsForProjectCommand extends Command
                 $this,
                 $cwd,
                 $rootPackage,
-                PieJsonEditor::fromTargetPlatform(CommandHelper::determineTargetPlatformFromInputs($input, new NullIO())),
+                PieJsonEditor::fromTargetPlatform($targetPlatform),
                 $input,
                 $this->io,
             );
@@ -141,8 +144,6 @@ final class InstallExtensionsForProjectCommand extends Command
 
             return Command::FAILURE;
         }
-
-        $targetPlatform = CommandHelper::determineTargetPlatformFromInputs($input, $this->io);
 
         $this->io->write(sprintf(
             'Checking extensions for your project <info>%s</info> (path: %s)',
@@ -314,5 +315,23 @@ final class InstallExtensionsForProjectCommand extends Command
         $restoreWorkingDir();
 
         return $anyErrorsHappened ? self::FAILURE : self::SUCCESS;
+    }
+
+    private static function warnIfTargetPhpDoesNotSatisfyComposerRequirement(Link|null $phpRequirement, TargetPlatform $targetPlatform, IOInterface $io): void
+    {
+        if ($phpRequirement === null) {
+            return;
+        }
+
+        $targetPhpVersion = $targetPlatform->phpBinaryPath->version();
+        if ($phpRequirement->getConstraint()->matches((new VersionParser())->parseConstraints($targetPhpVersion))) {
+            return;
+        }
+
+        $io->writeError(sprintf(
+            '<warning>Target PHP %s does not satisfy composer.json requirement php:%s.</warning>',
+            $targetPhpVersion,
+            $phpRequirement->getPrettyConstraint(),
+        ));
     }
 }

--- a/test/integration/Command/InstallExtensionsForProjectCommandTest.php
+++ b/test/integration/Command/InstallExtensionsForProjectCommandTest.php
@@ -201,6 +201,40 @@ final class InstallExtensionsForProjectCommandTest extends TestCase
         self::assertStringContainsString('Multiple packages were found for ext-foobar', $outputString);
     }
 
+    public function testWarnsWhenTargetPhpDoesNotSatisfyProjectPhpRequirement(): void
+    {
+        $rootPackage = new RootPackage('my/project', '1.2.3.0', '1.2.3');
+        $rootPackage->setRequires([
+            'php' => new Link('my/project', 'php', new Constraint('>=', '999.0.0.0-dev'), Link::TYPE_REQUIRE, '^999.0'),
+        ]);
+        $this->composerFactoryForProject->method('rootPackage')->willReturn($rootPackage);
+
+        $installedRepository = new InstalledArrayRepository([$rootPackage]);
+
+        $repositoryManager = $this->createMock(RepositoryManager::class);
+        $repositoryManager->method('getLocalRepository')->willReturn($installedRepository);
+
+        $composer = $this->createMock(Composer::class);
+        $composer->method('getPackage')->willReturn($rootPackage);
+        $composer->method('getRepositoryManager')->willReturn($repositoryManager);
+
+        $this->composerFactoryForProject->method('composer')->willReturn($composer);
+        $this->installedPiePackages->method('allPiePackages')->willReturn(new PiePackageList([]));
+
+        $this->commandTester->execute(
+            ['--allow-non-interactive-project-install' => true],
+            ['verbosity' => BufferedOutput::VERBOSITY_VERY_VERBOSE],
+        );
+
+        $outputString = $this->commandTester->getDisplay();
+
+        $this->commandTester->assertCommandIsSuccessful($outputString);
+        self::assertStringContainsString(
+            'does not satisfy composer.json requirement php:^999.0.',
+            $outputString,
+        );
+    }
+
     public function testInstallingExtensionsForPieProject(): void
     {
         $rootPackage = new RootPackage('my/project', '1.2.3.0', '1.2.3');


### PR DESCRIPTION
Just small silly feature. When using `install-extensions-for-project` command, and your composer.json needs a newer PHP than your target PHP, print a little warning:

> Target PHP 8.2 does not satisfy composer.json requirement php:^8.3.

🤔 Maybe it should also check the composer.lock, since it contains a combination of all the package requirements as well.

This is LLM assisted code, Codex with GPT 5.5 Low.

## PR submitter checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/php/pie/blob/HEAD/CONTRIBUTING.md)
- [ ] I discussed this <bug|feature> with the maintainers in #<issue_number> (complete as appropriate)
- [x] I have added appropriate tests
- [ ] I confirm that I have the right to submit this under the project's open source licence
