### PR TITLE
more rpm providers (for dnf tips)

### DIFF
--- a/src/DependencyResolver/ResolveDependencyWithComposer.php
+++ b/src/DependencyResolver/ResolveDependencyWithComposer.php
@@ -138,7 +138,15 @@ final class ResolveDependencyWithComposer implements DependencyResolver
             ));
         }
 
-        if ($buildProvider === 'Remi\'s RPM repository <https://rpms.remirepo.net/> #StandWithUkraine') {
+        $rpmProviders = [
+            'AlmaLinux',
+            'CentOS',
+            'Fedora Project',
+            'Red Hat, Inc.',
+            'Remi\'s RPM repository <https://rpms.remirepo.net/> #StandWithUkraine',
+            'Rocky Enterprise Software Foundation',
+        ];
+        if (in_array($buildProvider, $rpmProviders)) {
             $identifiedBuildProvider = true;
             $this->io->write(sprintf(
                 '<comment>%sYou should probably use "dnf install php-%s" instead</comment>',

--- a/test/end-to-end/Dockerfile
+++ b/test/end-to-end/Dockerfile
@@ -6,20 +6,20 @@ RUN cd /app && touch creating_this_means_phar_will_never_be_verified && /box.pha
 FROM alpine AS test_pie_installs_build_tools_on_alpine
 RUN apk add php php-phar php-mbstring php-iconv php-openssl bzip2-dev libbz2
 COPY --from=build_pie_phar /app/pie.phar /usr/local/bin/pie
-RUN pie install --auto-install-build-tools -v php/bz2
+RUN pie install --auto-install-build-tools -v asgrim/example-pie-extension
 RUN apk del .php-pie-deps
 RUN pie show
 
 FROM fedora AS test_pie_installs_build_tools_on_fedora
 RUN dnf install -y php php-pecl-zip unzip bzip2-devel
 COPY --from=build_pie_phar /app/pie.phar /usr/local/bin/pie
-RUN pie install --auto-install-build-tools -v php/bz2
+RUN pie install --auto-install-build-tools -v asgrim/example-pie-extension
 RUN pie show
 
 FROM ubuntu AS test_pie_installs_build_tools_on_ubuntu
 RUN apt-get update && apt-get install -y php unzip libbz2-dev
 COPY --from=build_pie_phar /app/pie.phar /usr/local/bin/pie
-RUN pie install --auto-install-build-tools -v php/bz2
+RUN pie install --auto-install-build-tools -v asgrim/example-pie-extension
 RUN pie show
 
 FROM homebrew/brew AS test_pie_installs_build_tools_with_brew
@@ -47,14 +47,14 @@ RUN mkdir -p /opt/php \
     && make install
 ENV PATH="$PATH:/opt/php/bin"
 COPY --from=build_pie_phar /app/pie.phar /usr/local/bin/pie
-RUN pie install -v --auto-install-system-dependencies php/sodium
+RUN pie install -v --auto-install-system-dependencies --force php/sodium
 
 FROM alpine AS test_pie_installs_system_deps_on_alpine
 RUN apk add php php-phar php-mbstring php-iconv php-openssl bzip2-dev libbz2 build-base autoconf bison re2c libtool php85-dev
 COPY --from=build_pie_phar /app/pie.phar /usr/local/bin/pie
-RUN pie install -v --auto-install-system-dependencies php/sodium
+RUN pie install -v --auto-install-system-dependencies --force php/sodium
 
 FROM fedora AS test_pie_installs_system_deps_on_fedora
 RUN dnf install -y php php-pecl-zip unzip gcc make autoconf bison re2c libtool php-devel
 COPY --from=build_pie_phar /app/pie.phar /usr/local/bin/pie
-RUN pie install -v --auto-install-system-dependencies php/sodium
+RUN pie install -v --auto-install-system-dependencies --force php/sodium


### PR DESCRIPTION
The tips about using dnf is really not enough, only my repo case is handled

This add a list of the most common RPM distro using DNF (at least the one I care about)

## PR submitter checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/php/pie/blob/HEAD/CONTRIBUTING.md)
- [ ] I discussed this <bug|feature> with the maintainers in #<issue_number> (complete as appropriate)
- [ ] I have added appropriate tests
- [x] I confirm that I have the right to submit this under the project's open source licence


But this is really not a complete list, lot are missing (Mandriva, Oracle, SuSe, other RHEL clone...),
And not robust (string may change across distro versions)

I better approch will be to check the output of 
```
$ rpm -qf --qf "%{NAME}\n" /usr/bin/php
php-cli
```

And the suggested command should be  `dnf install xxx` , xx being previous result with "cli" replaced by ext name

The package can be php-cli, php8.4-cli (new in EL-10.2) or php84-php-cli (Sowftare collections)