### PR TITLE
Support operator

### DIFF
--- a/docs/supported-extensions.md
+++ b/docs/supported-extensions.md
@@ -70,6 +70,7 @@ The following extensions have already added support for PIE:
 | mysqlnd        | php/mysqlnd                                                                                         |
 | mysqli         | php/mysqli                                                                                          |
 | opcache        | php/opcache                                                                                         |
+| operator       | [jblo/operator](https://packagist.org/packages/jblo/operator)                                       |
 | opentelemetry  | [open-telemetry/ext-opentelemetry](https://packagist.org/packages/open-telemetry/ext-opentelemetry) |
 | parallel       | [pecl/parallel](https://packagist.org/packages/pecl/parallel)                                       |
 | pcov           | [pecl/pcov](https://packagist.org/packages/pecl/pcov)                                               |
@@ -412,7 +413,6 @@ The following extensions are believed to be abandoned:
 * odbtp
 * oggvorbis
 * opendirectory
-* operator
 * optimizer
 * orng
 * panda


### PR DESCRIPTION
<!--- ext/operator was abandoned by its original maintainers in 2018. -->
<!--- I added support for PHP8.2+ in 2024. -->
<!--- I created the PR to update the PECL repo in early 2025. -->
<!--- https://github.com/php/pecl-php-operator/pull/6 -->
<!--- I was given access to PECL as the new lead maintainer, -->
<!-- https://pecl.php.net/package/operator -->
<!--- but no one would give me approval for the GitHub repo. -->
