### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 PIE is the official installer for PHP extensions, which replaces
 [PECL](https://pecl.php.net/) (which is now deprecated). PIE is distributed as a
-[PHAR](https://www.php.net/manual/en/intro.phar.php), just like Composer, and
+[PHAR](https://www.php.net/manual/en/book.phar.php), just like Composer, and
 works in a similar way to Composer, but it installs PHP extensions (PHP Modules
 or Zend Extensions) to your PHP installation, rather than pulling PHP packages
 into your project or library.


### PR DESCRIPTION
Fix link to PHP phar extension description, which was moved Feb 2026 and the redirect was apparently disabled in March or April 2026, see [link](https://web.archive.org/web/20260000000000*/https://www.php.net/manual/en/intro.phar.php)

## PR submitter checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/php/pie/blob/HEAD/CONTRIBUTING.md)
- [ ] I discussed this <bug|feature> with the maintainers in #<issue_number> (complete as appropriate)
- [ ] I have added appropriate tests
- [x] I confirm that I have the right to submit this under the project's open source licence

It's just a small fix in the readme…