### PR TITLE
refactor: enhance UX for missing build tools prompt

### DIFF
--- a/src/DependencyResolver/DependencyInstaller/PrescanSystemDependencies.php
+++ b/src/DependencyResolver/DependencyInstaller/PrescanSystemDependencies.php
@@ -99,7 +99,7 @@ class PrescanSystemDependencies
         $this->io->write(sprintf('<info>Need to install missing system dependencies:</info> %s', $proposedInstallCommand));
 
         if ($this->io->isInteractive() && ! $autoInstallIfMissing) {
-            if (! $this->io->askConfirmation('<question>Would you like to install them now?</question>', false)) {
+            if (! $this->io->askConfirmation('<question>Would you like to install them now? [y/N]</question>', false)) {
                 $this->io->write('<comment>Ok, but things might not work. Just so you know.</comment>');
 
                 return;

--- a/src/SelfManage/BuildTools/CheckAllBuildTools.php
+++ b/src/SelfManage/BuildTools/CheckAllBuildTools.php
@@ -171,7 +171,7 @@ class CheckAllBuildTools
         $io->write('The following command will be run: ' . $proposedInstallCommand, verbosity: IOInterface::VERBOSE);
 
         if ($io->isInteractive() && ! $autoInstallIfMissing) {
-            if (! $io->askConfirmation('<question>Would you like to install them now?</question>', false)) {
+            if (! $io->askConfirmation('<question>Would you like to install them now? [y/N]</question>', false)) {
                 $io->write('<comment>Ok, but things might not work. Just so you know.</comment>');
 
                 return;

--- a/test/unit/SelfManage/BuildTools/CheckAllBuildToolsTest.php
+++ b/test/unit/SelfManage/BuildTools/CheckAllBuildToolsTest.php
@@ -79,6 +79,7 @@ final class CheckAllBuildToolsTest extends TestCase
         $outputString = $io->getOutput();
         self::assertStringContainsString('Checking if all build tools are installed.', $outputString);
         self::assertStringContainsString('The following build tools are missing: bloop', $outputString);
+        self::assertStringContainsString('Would you like to install them now? [y/N]', $outputString);
         self::assertStringContainsString('The following command will be run: echo "fake installing coreutils"', $outputString);
         self::assertStringContainsString('Missing build tools have been installed.', $outputString);
     }


### PR DESCRIPTION
This is a little UX improvement PR. When a tool is missing, pie will ask the user for installation conformation, but it lacks some instruction to tell the user what to do next and what is the default action.

So I just update the question prompt from:

```text
Would you like to install them now?
````

to:

```text
Would you like to install them now? [y/N]
```

The `[y/N]` tells the user can type `y` or `n`, and `n` is the default action.

## PR submitter checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/php/pie/blob/HEAD/CONTRIBUTING.md)
- [x] I discussed this feature with the maintainers in #649 
- [x] I have added appropriate tests
- [x] I confirm that I have the right to submit this under the project's open source license
