### PR TITLE
609: Re-enable windows pie.exe builds with VS22

### DIFF
--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -79,7 +79,7 @@ jobs:
           - ubuntu-24.04-arm
           - macos-15-intel
           - macos-26
-#          - windows-2025 - disabled for now, seems broken
+          - windows-2022
     permissions:
       contents: read
       # id-token:write is required for build provenance attestation.


### PR DESCRIPTION
Fixes #609 

Use windows-2022 which has VS22 still (windows-2025 moved to VC26)

https://github.blog/changelog/2026-02-05-github-actions-early-february-2026-updates/#windows-server-2025-with-visual-studio-2026-image-now-available-for-github-hosted-runners

## PR submitter checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/php/pie/blob/HEAD/CONTRIBUTING.md)
- [x] I discussed this bug with the maintainers in #609 
- [x] I have added appropriate tests
- [x] I confirm that I have the right to submit this under the project's open source licence
