### PR TITLE
646: remove additional newline from subprocess callback

### DIFF
--- a/src/Util/Process.php
+++ b/src/Util/Process.php
@@ -71,7 +71,7 @@ final class Process
                 $type === SymfonyProcess::ERR ? '<comment>' : '',
                 $outputMessage,
                 $type === SymfonyProcess::ERR ? '</comment>' : '',
-            ));
+            ), false);
         };
     }
 


### PR DESCRIPTION
Fixes #646 

## PR submitter checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/php/pie/blob/HEAD/CONTRIBUTING.md)
- [x] I discussed this bug with the maintainers in #646 
- [x] I have added appropriate tests
- [x] I confirm that I have the right to submit this under the project's open source licence
