### PR TITLE
585: improve messaging when no auth available during verify

### DIFF
--- a/src/SelfManage/Verify/FailedToVerifyRelease.php
+++ b/src/SelfManage/Verify/FailedToVerifyRelease.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Php\Pie\SelfManage\Verify;
 
+use Composer\Downloader\TransportException;
 use Php\Pie\SelfManage\Update\ReleaseMetadata;
 use RuntimeException;
 use Symfony\Component\Process\Exception\ProcessFailedException;
@@ -14,6 +15,18 @@ use function trim;
 
 class FailedToVerifyRelease extends RuntimeException
 {
+    public static function fromGithubAuthenticationFailure(TransportException $transportException): self
+    {
+        return new self(
+            $transportException->getMessage() . ' while downloading attestation to verify PIE. This likely '
+            . 'means you have not set up GitHub authentication in Composer yet. PIE relies on this Composer '
+            . 'authentication configuration to make API requests to GitHub; check out '
+            . 'https://getcomposer.org/doc/articles/authentication-for-private-packages.md#command-line-github-oauth'
+            . 'for help configuring Composer, or set GITHUB_TOKEN if the environment makes sense',
+            previous: $transportException,
+        );
+    }
+
     public static function fromAttestationException(FailedToVerifyArtifact $failedToVerifyArtifact): self
     {
         return new self($failedToVerifyArtifact->getMessage(), 0, $failedToVerifyArtifact);

--- a/src/SelfManage/Verify/FallbackVerificationUsingOpenSsl.php
+++ b/src/SelfManage/Verify/FallbackVerificationUsingOpenSsl.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Php\Pie\SelfManage\Verify;
 
+use Composer\Downloader\TransportException;
 use Composer\IO\IOInterface;
 use Php\Pie\File\BinaryFile;
 use Php\Pie\SelfManage\Update\FetchPieRelease;
@@ -73,6 +74,12 @@ final class FallbackVerificationUsingOpenSsl implements VerifyPiePhar
             );
         } catch (FailedToVerifyArtifact $failedToVerifyArtifact) {
             throw FailedToVerifyRelease::fromAttestationException($failedToVerifyArtifact);
+        } catch (TransportException $transportException) {
+            if ($transportException->getStatusCode() === 401) {
+                throw FailedToVerifyRelease::fromGithubAuthenticationFailure($transportException);
+            }
+
+            throw $transportException;
         }
 
         $io->write(sprintf(


### PR DESCRIPTION
Fixes #585 

## PR submitter checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/php/pie/blob/HEAD/CONTRIBUTING.md)
- [x] I discussed this feature with the maintainers in #585
- [x] I have added appropriate tests
- [x] I confirm that I have the right to submit this under the project's open source licence
