### PR TITLE
631: remove abandoned packages from bySearching/byProvider

### DIFF
--- a/src/Installing/InstallForPhpProject/FindMatchingPackages.php
+++ b/src/Installing/InstallForPhpProject/FindMatchingPackages.php
@@ -34,22 +34,34 @@ class FindMatchingPackages
      */
     private function filterToCompatible(Composer $pieComposer, array $matches, string $searchTerm): array
     {
-        if (ExtensionName::isValidExtensionName($searchTerm)) {
-            $extensionName = ExtensionName::normaliseFromString($searchTerm);
+        $normalisedExtensionNameIfValid = ExtensionName::isValidExtensionName($searchTerm)
+            ? ExtensionName::normaliseFromString($searchTerm)
+            : null;
 
-            $matches = array_filter(
-                $matches,
-                static function (array $match) use ($pieComposer, $extensionName): bool {
-                    $package = $pieComposer->getRepositoryManager()->findPackage($match['name'], '*');
+        $matches = array_filter(
+            $matches,
+            static function (array $match) use ($pieComposer, $normalisedExtensionNameIfValid): bool {
+                $package = $pieComposer->getRepositoryManager()->findPackage($match['name'], '*');
 
-                    if (! $package instanceof CompletePackageInterface || ! ExtensionType::isValid($package->getType())) {
-                        return false;
-                    }
+                /** Don't include abandoned packages */
+                if ($package instanceof CompletePackageInterface && $package->isAbandoned()) {
+                    return false;
+                }
 
-                    return Package::fromComposerCompletePackage($package)->extensionName()->name() === $extensionName->name();
-                },
-            );
-        }
+                /** Allows "search results", used for {@see bySearching()} where the search term might not be an extension name*/
+                if ($normalisedExtensionNameIfValid === null) {
+                    return true;
+                }
+
+                /** Don't include packages without type php-ext or php-ext-zend */
+                if (! $package instanceof CompletePackageInterface || ! ExtensionType::isValid($package->getType())) {
+                    return false;
+                }
+
+                /** Return if the package extension name (derived or explicit) matches what we are looking for */
+                return Package::fromComposerCompletePackage($package)->extensionName()->name() === $normalisedExtensionNameIfValid->name();
+            },
+        );
 
         if (! count($matches)) {
             throw new OutOfRangeException('No matches found for ' . $searchTerm);

--- a/test/unit/Installing/InstallForPhpProject/FindMatchingPackagesTest.php
+++ b/test/unit/Installing/InstallForPhpProject/FindMatchingPackagesTest.php
@@ -12,6 +12,7 @@ use Composer\Package\CompletePackageInterface;
 use Composer\Repository\ArrayRepository;
 use Composer\Repository\RepositoryManager;
 use Composer\Util\HttpDownloader;
+use OutOfRangeException;
 use Php\Pie\ExtensionName;
 use Php\Pie\ExtensionType;
 use Php\Pie\Installing\InstallForPhpProject\FindMatchingPackages;
@@ -71,6 +72,49 @@ final class FindMatchingPackagesTest extends TestCase
         );
     }
 
+    public function testAbandonedPackageIsExcludedFromSearchResults(): void
+    {
+        $repository = new ArrayRepository([
+            (static function (): CompletePackageInterface {
+                $package = new CompletePackage('foo/bar', '1.2.3.0', '1.2.3');
+                $package->setDescription('The best extension there is');
+                $package->setType(ExtensionType::PhpModule->value);
+                $package->setAbandoned(true);
+
+                return $package;
+            })(),
+            (static function (): CompletePackageInterface {
+                $package = new CompletePackage('baz/bar', '2.0.0.0', '2.0.0');
+                $package->setDescription('A perfectly maintained extension');
+                $package->setType(ExtensionType::PhpModule->value);
+
+                return $package;
+            })(),
+        ]);
+
+        $repoManager = new RepositoryManager(
+            $this->createMock(IOInterface::class),
+            $this->createMock(Config::class),
+            $this->createMock(HttpDownloader::class),
+            null,
+            null,
+        );
+        $repoManager->addRepository($repository);
+
+        $composer = $this->createMock(Composer::class);
+        $composer->method('getRepositoryManager')->willReturn($repoManager);
+
+        self::assertSame(
+            [
+                [
+                    'name' => 'baz/bar',
+                    'description' => 'A perfectly maintained extension',
+                ],
+            ],
+            (new FindMatchingPackages())->bySearching($composer, 'bar'),
+        );
+    }
+
     public function testByProvider(): void
     {
         $package = new CompletePackage('foo/bar', '2.0.0.0', '2.0.0');
@@ -117,5 +161,42 @@ final class FindMatchingPackagesTest extends TestCase
             ],
             (new FindMatchingPackages())->byProvider($composer, ExtensionName::normaliseFromString('bar')),
         );
+    }
+
+    public function testAbandonedPackageIsExcludedFromProviderResults(): void
+    {
+        $package = new CompletePackage('foo/bar', '2.0.0.0', '2.0.0');
+        $package->setDescription('The best extension there is');
+        $package->setType(ExtensionType::PhpModule->value);
+        $package->setAbandoned(true);
+
+        $repository = $this->createPartialMock(ArrayRepository::class, ['getProviders']);
+        $repository->addPackage($package);
+        $repository->expects(self::once())
+            ->method('getProviders')
+            ->with('ext-bar')
+            ->willReturn([
+                'foo/bar' => [
+                    'name' => 'foo/bar',
+                    'description' => 'The best extension there is',
+                    'type' => 'php-ext',
+                ],
+            ]);
+
+        $repoManager = new RepositoryManager(
+            $this->createMock(IOInterface::class),
+            $this->createMock(Config::class),
+            $this->createMock(HttpDownloader::class),
+            null,
+            null,
+        );
+        $repoManager->addRepository($repository);
+
+        $composer = $this->createMock(Composer::class);
+        $composer->method('getRepositoryManager')->willReturn($repoManager);
+
+        $this->expectException(OutOfRangeException::class);
+
+        (new FindMatchingPackages())->byProvider($composer, ExtensionName::normaliseFromString('bar'));
     }
 }


### PR DESCRIPTION
Fixes #631 

## PR submitter checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/php/pie/blob/HEAD/CONTRIBUTING.md)
- [x] I discussed this feature with the maintainers in #631 
- [x] I have added appropriate tests
- [x] I confirm that I have the right to submit this under the project's open source licence

```
🥧 PHP Installer for Extensions (PIE) 1.4.8@955aece, from The PHP Foundation
You are running PHP 8.5.4
Target PHP installation: 8.5.4 nts, on Linux/OSX/etc x86_64 (from /usr/local/bin/php)
Checking extensions for your project asgrim/demo-php-project (path: /demos/demo-php-project)
requires: ext-curl:* ✅ Already installed
requires: ext-example_pie_extension:^2.0 🚫 Missing

The following packages may be suitable, which would you like to install: 
  [0] None
  [1] asgrim/example-pie-extension: Example PIE extension
 > 0
Okay I won't install anything for example_pie_extension
requires: ext-redis:* 🚫 Missing

The following packages may be suitable, which would you like to install: 
  [0] None
  [1] phpredis/phpredis: A PHP extension for Redis
 > 0
Okay I won't install anything for redis
```

^^ abandoned package [`pie-extensions/redis`](https://packagist.org/packages/pie-extensions/redis) will no longer appear in suggestions :)
