### PR TITLE
Add lib-gpgme as a supported system library

### DIFF
--- a/docs/extension-maintainers.md
+++ b/docs/extension-maintainers.md
@@ -395,6 +395,7 @@ is NOT working, then please [report a bug](https://github.com/php/pie/issues).
 | lib-freetype2 | ✅              | ❌                  |
 | lib-gdlib     | ✅              | ❌                  |
 | lib-gmp       | ✅              | ❌                  |
+| lib-gpgme     | ✅              | apt, apk, dnf, yum |
 | lib-sasl      | ✅              | ❌                  |
 | lib-onig      | ✅              | ❌                  |
 | lib-odbc      | ✅              | ❌                  |

--- a/src/ComposerIntegration/PhpBinaryPathBasedPlatformRepository.php
+++ b/src/ComposerIntegration/PhpBinaryPathBasedPlatformRepository.php
@@ -171,6 +171,7 @@ class PhpBinaryPathBasedPlatformRepository extends PlatformRepository
         $this->detectLibraryWithPkgConfig('freetype2', 'freetype2');
         $this->detectLibraryWithPkgConfig('gdlib', 'gdlib');
         $this->detectLibraryWithPkgConfig('gmp', 'gmp');
+        $this->detectLibraryWithPkgConfig('gpgme', 'gpgme');
         $this->detectLibraryWithPkgConfig('sasl', 'libsasl2');
         $this->detectLibraryWithPkgConfig('onig', 'oniguruma');
         $this->detectLibraryWithPkgConfig('odbc', 'libiodbc');

--- a/src/DependencyResolver/DependencyInstaller/SystemDependenciesDefinition.php
+++ b/src/DependencyResolver/DependencyInstaller/SystemDependenciesDefinition.php
@@ -62,6 +62,13 @@ class SystemDependenciesDefinition
                 PackageManager::Microdnf->value => 'pkgconfig(libcurl)',
                 PackageManager::Yum->value => 'pkgconfig(libcurl)',
             ],
+            'gpgme' => [
+                PackageManager::Apt->value => 'libgpgme-dev',
+                PackageManager::Apk->value => 'gpgme-dev',
+                PackageManager::Dnf->value => 'pkgconfig(gpgme)',
+                PackageManager::Microdnf->value => 'pkgconfig(gpgme)',
+                PackageManager::Yum->value => 'pkgconfig(gpgme)',
+            ],
         ]);
     }
 }

--- a/test/unit/ComposerIntegration/PhpBinaryPathBasedPlatformRepositoryTest.php
+++ b/test/unit/ComposerIntegration/PhpBinaryPathBasedPlatformRepositoryTest.php
@@ -176,6 +176,7 @@ final class PhpBinaryPathBasedPlatformRepositoryTest extends TestCase
                 ['freetype2', 'freetype2'],
                 ['gdlib', 'gdlib'],
                 ['gmp', 'gmp'],
+                ['gpgme', 'gpgme'],
                 ['sasl', 'libsasl2'],
                 ['onig', 'oniguruma'],
                 ['odbc', 'libiodbc'],


### PR DESCRIPTION
Register the GpgME library so extensions that wrap it (e.g. php-gnupg/gnupg) can declare a `lib-gpgme` dependency in composer.json. GpgME exposes a `gpgme` pkg-config module, so it is detected the same way as the other supported libraries, and can be auto-installed via apt (libgpgme-dev), apk (gpgme-dev), and dnf/yum (pkgconfig(gpgme)).

<!--- IMPORTANT - READ BEFORE SUBMITTING YOUR PR -->
<!--- If you have not discussed this change with us this change before -->
<!--- submitting a Pull Request, you may be duplicating work already in -->
<!--- progress. Please either open an issue (for bugs), or create a -->
<!--- discussion (for features), and discuss the change BEFORE working -->
<!--- on it, so you are not wasting your time... -->

## PR submitter checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/php/pie/blob/HEAD/CONTRIBUTING.md)
- [x] I discussed this feature with the maintainers in #678
- [x] I have added appropriate tests
- [x] I confirm that I have the right to submit this under the project's open source licence
