### PR TITLE
Fix help message when no packages are found

### DIFF
--- a/src/Installing/InstallForPhpProject/NoMatchingPackagesFound.php
+++ b/src/Installing/InstallForPhpProject/NoMatchingPackagesFound.php
@@ -15,7 +15,7 @@ class NoMatchingPackagesFound extends RuntimeException
     public static function forExtension(ExtensionName $extensionName): self
     {
         return new self(sprintf(
-            'PIE could not find any potential matches for %s; if you know which package to use, specify --select=vendor/package in the `pie install` options.',
+            'PIE could not find any potential matches for %s; if you know which package to use, specify --select extension=vendor/package in the `pie install` options.',
             $extensionName->nameWithExtPrefix(),
         ));
     }


### PR DESCRIPTION
The --select option expects the following format:

  --select extension=vendor/package

But the help message lacked the "extension=" part.

<!--- IMPORTANT - READ BEFORE SUBMITTING YOUR PR -->
<!--- If you have not discussed this change with us this change before -->
<!--- submitting a Pull Request, you may be duplicating work already in -->
<!--- progress. Please either open an issue (for bugs), or create a -->
<!--- discussion (for features), and discuss the change BEFORE working -->
<!--- on it, so you are not wasting your time... -->

## PR submitter checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/php/pie/blob/HEAD/CONTRIBUTING.md)
- [x] I discussed this <bug|feature> with the maintainers in #688
- [x] I have added appropriate tests (no test needed)
- [x] I confirm that I have the right to submit this under the project's open source licence
