### PR TITLE
Add lib-pam as a supported system library

### DIFF
--- a/docs/extension-maintainers.md
+++ b/docs/extension-maintainers.md
@@ -396,6 +396,7 @@ is NOT working, then please [report a bug](https://github.com/php/pie/issues).
 | lib-gdlib     | ✅              | ❌                  |
 | lib-gmp       | ✅              | ❌                  |
 | lib-gpgme     | ✅              | apt, apk, dnf, yum |
+| lib-pam       | ✅              | apt, apk, dnf, yum |
 | lib-sasl      | ✅              | ❌                  |
 | lib-onig      | ✅              | ❌                  |
 | lib-odbc      | ✅              | ❌                  |

--- a/src/ComposerIntegration/PhpBinaryPathBasedPlatformRepository.php
+++ b/src/ComposerIntegration/PhpBinaryPathBasedPlatformRepository.php
@@ -172,6 +172,7 @@ class PhpBinaryPathBasedPlatformRepository extends PlatformRepository
         $this->detectLibraryWithPkgConfig('gdlib', 'gdlib');
         $this->detectLibraryWithPkgConfig('gmp', 'gmp');
         $this->detectLibraryWithPkgConfig('gpgme', 'gpgme');
+        $this->detectLibraryWithPkgConfig('pam', 'pam');
         $this->detectLibraryWithPkgConfig('sasl', 'libsasl2');
         $this->detectLibraryWithPkgConfig('onig', 'oniguruma');
         $this->detectLibraryWithPkgConfig('odbc', 'libiodbc');

--- a/src/DependencyResolver/DependencyInstaller/SystemDependenciesDefinition.php
+++ b/src/DependencyResolver/DependencyInstaller/SystemDependenciesDefinition.php
@@ -69,6 +69,13 @@ class SystemDependenciesDefinition
                 PackageManager::Microdnf->value => 'pkgconfig(gpgme)',
                 PackageManager::Yum->value => 'pkgconfig(gpgme)',
             ],
+            'pam' => [
+                PackageManager::Apt->value => 'libpam0g-dev',
+                PackageManager::Apk->value => 'linux-pam-dev',
+                PackageManager::Dnf->value => 'pkgconfig(pam)',
+                PackageManager::Microdnf->value => 'pkgconfig(pam)',
+                PackageManager::Yum->value => 'pkgconfig(pam)',
+            ],
         ]);
     }
 }

--- a/test/unit/ComposerIntegration/PhpBinaryPathBasedPlatformRepositoryTest.php
+++ b/test/unit/ComposerIntegration/PhpBinaryPathBasedPlatformRepositoryTest.php
@@ -177,6 +177,7 @@ final class PhpBinaryPathBasedPlatformRepositoryTest extends TestCase
                 ['gdlib', 'gdlib'],
                 ['gmp', 'gmp'],
                 ['gpgme', 'gpgme'],
+                ['pam', 'pam'],
                 ['sasl', 'libsasl2'],
                 ['onig', 'oniguruma'],
                 ['odbc', 'libiodbc'],


### PR DESCRIPTION
Register the (Linux-)PAM library so extensions that wrap it (e.g. amishmm/pam) can declare a `lib-pam` dependency in composer.json. Linux-PAM exposes a `pam` pkg-config module, so it is detected the same way as the other supported libraries, and can be auto-installed via apt (libpam0g-dev), apk (linux-pam-dev), and dnf/yum (pkgconfig(pam)).

<!--- IMPORTANT - READ BEFORE SUBMITTING YOUR PR -->
<!--- If you have not discussed this change with us this change before -->
<!--- submitting a Pull Request, you may be duplicating work already in -->
<!--- progress. Please either open an issue (for bugs), or create a -->
<!--- discussion (for features), and discuss the change BEFORE working -->
<!--- on it, so you are not wasting your time... -->

## PR submitter checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/php/pie/blob/HEAD/CONTRIBUTING.md)
- [x] I discussed this feature with the maintainers in #689
- [x] I have added appropriate tests
- [x] I confirm that I have the right to submit this under the project's open source licence
