### PR TITLE
692: suppress warning about INI setup if --skip-enable-extension was supplied

### DIFF
--- a/src/Installing/SetupIniFile.php
+++ b/src/Installing/SetupIniFile.php
@@ -39,11 +39,9 @@ class SetupIniFile
                 $downloadedPackage->package->prettyNameAndVersion(),
                 $targetPlatform->phpBinaryPath->phpBinaryPath,
             ));
+        } elseif (! $attemptToSetupIniFile) {
+            $io->write('Automatic extension enabling was skipped.', verbosity: IOInterface::VERBOSE);
         } else {
-            if (! $attemptToSetupIniFile) {
-                $io->write('Automatic extension enabling was skipped.', verbosity: IOInterface::VERY_VERBOSE);
-            }
-
             $io->write(sprintf('<comment>%s Extension has NOT been automatically enabled.</comment>', Emoji::WARNING));
             $io->write(sprintf(
                 '<comment>You must now add "%s=%s" to your php.ini</comment>',

--- a/test/behaviour/CliContext.php
+++ b/test/behaviour/CliContext.php
@@ -250,7 +250,7 @@ class CliContext implements Context
     public function iRunACommandToInstallAnExtensionWithoutEnabling(): void
     {
         $this->interactions[] = ['extension' => 'example_pie_extension', 'package' => 'asgrim/example-pie-extension'];
-        $this->runPieCommand(['install', 'asgrim/example-pie-extension', '--skip-enable-extension']);
+        $this->runPieCommand(['install', 'asgrim/example-pie-extension', '--skip-enable-extension', '-v']);
     }
 
     #[When('I run a command to uninstall an extension')]
@@ -297,7 +297,9 @@ class CliContext implements Context
     {
         $this->assertCommandSuccessful();
 
-        Assert::contains($this->output, 'Extension has NOT been automatically enabled.');
+        Assert::contains($this->output, 'Automatic extension enabling was skipped.');
+        Assert::notContains($this->output, 'Extension has NOT been automatically enabled.');
+        Assert::notContains($this->output, 'You must now add');
 
         foreach ($this->interactions as $install) {
             if (Platform::isWindows()) {

--- a/test/integration/Command/InstallCommandTest.php
+++ b/test/integration/Command/InstallCommandTest.php
@@ -111,7 +111,7 @@ class InstallCommandTest extends IsolatedWorkingDirectoryTestCase
         }
 
         self::assertStringContainsString('Install complete: ', $outputString);
-        self::assertStringContainsString('You must now add "extension=example_pie_extension" to your php.ini', $outputString);
+        self::assertStringNotContainsString('You must now add "extension=example_pie_extension" to your php.ini', $outputString);
     }
 
     #[RequiresOperatingSystemFamily('Windows')]
@@ -135,6 +135,6 @@ class InstallCommandTest extends IsolatedWorkingDirectoryTestCase
         }
 
         self::assertStringContainsString('Copied DLL to: ', $outputString);
-        self::assertStringContainsString('You must now add "extension=example_pie_extension" to your php.ini', $outputString);
+        self::assertStringNotContainsString('You must now add "extension=example_pie_extension" to your php.ini', $outputString);
     }
 }

--- a/test/unit/Installing/SetupIniFileTest.php
+++ b/test/unit/Installing/SetupIniFileTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\PieUnitTest\Installing;
+
+use Composer\IO\BufferIO;
+use Composer\Package\CompletePackageInterface;
+use Php\Pie\DependencyResolver\Package;
+use Php\Pie\Downloading\DownloadedPackage;
+use Php\Pie\ExtensionName;
+use Php\Pie\ExtensionType;
+use Php\Pie\File\BinaryFile;
+use Php\Pie\Installing\Ini\SetupIniApproach;
+use Php\Pie\Installing\SetupIniFile;
+use Php\Pie\Platform\Architecture;
+use Php\Pie\Platform\OperatingSystem;
+use Php\Pie\Platform\OperatingSystemFamily;
+use Php\Pie\Platform\TargetPhp\PhpBinaryPath;
+use Php\Pie\Platform\TargetPlatform;
+use Php\Pie\Platform\ThreadSafetyMode;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\StreamOutput;
+
+#[CoversClass(SetupIniFile::class)]
+final class SetupIniFileTest extends TestCase
+{
+    private DownloadedPackage $downloadedPackage;
+    private BinaryFile $binaryFile;
+    private TargetPlatform $targetPlatform;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $package = new Package(
+            $this->createMock(CompletePackageInterface::class),
+            ExtensionType::PhpModule,
+            ExtensionName::normaliseFromString('xdebug'),
+            'foo/bar',
+            '1.2.3',
+            null,
+        );
+
+        $this->downloadedPackage = DownloadedPackage::fromPackageAndExtractedPath($package, __DIR__);
+        $this->binaryFile        = new BinaryFile(__FILE__, 'abc123');
+
+        $phpBinaryPath = $this->createMock(PhpBinaryPath::class);
+        /** @phpstan-ignore property.notFound */
+        (fn () => $this->phpBinaryPath = '/usr/bin/php')
+            ->bindTo($phpBinaryPath, PhpBinaryPath::class)();
+
+        $this->targetPlatform = new TargetPlatform(
+            OperatingSystem::NonWindows,
+            OperatingSystemFamily::Linux,
+            $phpBinaryPath,
+            Architecture::x86_64,
+            ThreadSafetyMode::NonThreadSafe,
+            1,
+            null,
+            null,
+        );
+    }
+
+    public function testSuccessfulSetupPrintsEnabledMessage(): void
+    {
+        $setupIniApproach = $this->createMock(SetupIniApproach::class);
+        $setupIniApproach->method('canBeUsed')->willReturn(true);
+        $setupIniApproach->method('setup')->willReturn(true);
+
+        $io = new BufferIO();
+
+        (new SetupIniFile($setupIniApproach))(
+            $this->targetPlatform,
+            $this->downloadedPackage,
+            $this->binaryFile,
+            $io,
+            true,
+        );
+
+        $output = $io->getOutput();
+
+        self::assertStringContainsString('is enabled and loaded in', $output);
+        self::assertStringNotContainsString('Extension has NOT been automatically enabled.', $output);
+        self::assertStringNotContainsString('Automatic extension enabling was skipped.', $output);
+    }
+
+    public function testDeliberateSkipDoesNotPrintWarning(): void
+    {
+        $setupIniApproach = $this->createMock(SetupIniApproach::class);
+        $setupIniApproach->expects(self::never())->method('canBeUsed');
+        $setupIniApproach->expects(self::never())->method('setup');
+
+        $io = new BufferIO('', StreamOutput::VERBOSITY_VERBOSE);
+
+        (new SetupIniFile($setupIniApproach))(
+            $this->targetPlatform,
+            $this->downloadedPackage,
+            $this->binaryFile,
+            $io,
+            false,
+        );
+
+        $output = $io->getOutput();
+
+        self::assertStringContainsString('Automatic extension enabling was skipped.', $output);
+        self::assertStringNotContainsString('Extension has NOT been automatically enabled.', $output);
+        self::assertStringNotContainsString('You must now add', $output);
+    }
+
+    public function testAttemptedButFailedSetupPrintsWarning(): void
+    {
+        $setupIniApproach = $this->createMock(SetupIniApproach::class);
+        $setupIniApproach->method('canBeUsed')->willReturn(false);
+
+        $io = new BufferIO();
+
+        (new SetupIniFile($setupIniApproach))(
+            $this->targetPlatform,
+            $this->downloadedPackage,
+            $this->binaryFile,
+            $io,
+            true,
+        );
+
+        $output = $io->getOutput();
+
+        self::assertStringContainsString('Extension has NOT been automatically enabled.', $output);
+        self::assertStringContainsString('You must now add "extension=xdebug" to your php.ini', $output);
+        self::assertStringNotContainsString('Automatic extension enabling was skipped.', $output);
+    }
+}


### PR DESCRIPTION
Fixes #692 

## PR submitter checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/php/pie/blob/HEAD/CONTRIBUTING.md)
- [x] I discussed this feature with the maintainers in #692 
- [x] I have added appropriate tests
- [x] I confirm that I have the right to submit this under the project's open source licence
