### PR TITLE
Fix build provider detection for Remi

### DIFF
--- a/src/DependencyResolver/ResolveDependencyWithComposer.php
+++ b/src/DependencyResolver/ResolveDependencyWithComposer.php
@@ -114,7 +114,7 @@ final class ResolveDependencyWithComposer implements DependencyResolver
             throw BundledPhpExtensionRefusal::forPhpExtraVersion($targetPlatform->phpBinaryPath);
         }
 
-        $buildProvider           = $targetPlatform->phpBinaryPath->buildProvider();
+        $buildProvider = $targetPlatform->phpBinaryPath->buildProvider();
         if (! $buildProvider) {
             return;
         }
@@ -150,7 +150,7 @@ final class ResolveDependencyWithComposer implements DependencyResolver
             '|^Remi\'s RPM repository <https://rpms.remirepo.net/>|',
             'Rocky Enterprise Software Foundation',
         ];
-        foreach($rpmProviders as $rpmProvider) {
+        foreach ($rpmProviders as $rpmProvider) {
             if ($buildProvider === $rpmProvider || ($rpmProvider[0] === '|' && preg_match($rpmProvider, $buildProvider))) {
                 $identifiedBuildProvider = true;
                 $this->io->write(sprintf(

--- a/src/DependencyResolver/ResolveDependencyWithComposer.php
+++ b/src/DependencyResolver/ResolveDependencyWithComposer.php
@@ -143,16 +143,19 @@ final class ResolveDependencyWithComposer implements DependencyResolver
             'CentOS',
             'Fedora Project',
             'Red Hat, Inc.',
-            'Remi\'s RPM repository <https://rpms.remirepo.net/> #StandWithUkraine',
+            '|^Remi\'s RPM repository <https://rpms.remirepo.net/>|',
             'Rocky Enterprise Software Foundation',
         ];
-        if (in_array($buildProvider, $rpmProviders)) {
-            $identifiedBuildProvider = true;
-            $this->io->write(sprintf(
-                '<comment>%sYou should probably use "dnf install php-%s" instead</comment>',
-                $note,
-                $piePackage->extensionName()->name(),
-            ));
+        foreach($rpmProviders as $rpmProvider) {
+            if ($buildProvider === $rpmProvider || ($rpmProvider[0] === '|' && preg_match($rpmProvider, $buildProvider))) {
+                $identifiedBuildProvider = true;
+                $this->io->write(sprintf(
+                    '<comment>%sYou should probably use "dnf install php-%s" instead</comment>',
+                    $note,
+                    $piePackage->extensionName()->name(),
+                ));
+                break;
+            }
         }
 
         if ($buildProvider === 'Homebrew') {

--- a/src/DependencyResolver/ResolveDependencyWithComposer.php
+++ b/src/DependencyResolver/ResolveDependencyWithComposer.php
@@ -115,6 +115,10 @@ final class ResolveDependencyWithComposer implements DependencyResolver
         }
 
         $buildProvider           = $targetPlatform->phpBinaryPath->buildProvider();
+        if (! $buildProvider) {
+            return;
+        }
+
         $identifiedBuildProvider = false;
         $note                    = '<options=bold,underscore;fg=red>Note:</> ';
 


### PR DESCRIPTION
The Remi build provider string ends with a hashtag, but this may change

Ex: https://git.remirepo.net/cgit/tools/mock.git/diff/vendor.tpl?id=4f969f42ccd857ed9366c7b74fc6e587cc4ae56d
