### PR TITLE
docs: git is no longer an alternative to unzip since Composer 2.10

### DIFF
--- a/docs/ja/usage.md
+++ b/docs/ja/usage.md
@@ -48,7 +48,10 @@ COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
 
 #### Dockerfile での PIE の動作例
 
-これは Docker イメージ内で PIE を使用して拡張機能をインストールする方法の例です。Composer と同様に、`unzip`、[Zip](https://www.php.net/manual/ja/book.zip.php) 拡張機能、または `git` のようなものが必要です。
+これは Docker イメージ内で PIE を使用して拡張機能をインストールする方法の例です。Composer と同様に、ダウンロードしたパッケージを展開するために `unzip` または [Zip](https://www.php.net/manual/ja/book.zip.php) 拡張機能が必要です。
+
+> [!NOTE]
+> 以前は `git` がインストールされていれば代替となりました。展開に失敗した場合、Composer がソースからのチェックアウトにフォールバックしていたためです。Composer 2.10 はセキュリティ上の理由でこのフォールバックを削除し（[composer/composer#12885](https://github.com/composer/composer/pull/12885)）、PIE は 1.4.8 以降 Composer 2.10 を使用するため、`git` だけでは不十分です。`pie repository:add vcs ...` で追加したリポジトリなど、Composer が git 経由で読み取るリポジトリには引き続き必要です。
 
 ```Dockerfile
 FROM php:8.4-cli

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -63,9 +63,18 @@ Instead of `bin` tag (which represents latest binary-only image) you can also us
 #### Example of PIE working in a Dockerfile
 
 This is an example of how PIE could be used to install an extension inside a
-Docker image. Note that, like Composer, you need something like `unzip`, the
-[Zip](https://www.php.net/manual/en/book.zip.php) extension, or `git` to be
-installed.
+Docker image. Note that, like Composer, you need `unzip` or the
+[Zip](https://www.php.net/manual/en/book.zip.php) extension to be installed, so
+that the downloaded package can be extracted.
+
+> [!NOTE]
+> Having `git` installed used to be an alternative, because Composer fell back
+> to a source checkout when extraction failed. Composer 2.10 removed that
+> fallback for security reasons
+> ([composer/composer#12885](https://github.com/composer/composer/pull/12885)),
+> and PIE uses Composer 2.10 as of 1.4.8, so `git` on its own is no longer
+> enough. It is still needed for repositories that Composer reads over git,
+> such as those added with `pie repository:add vcs ...`.
 
 ```Dockerfile
 FROM php:8.4-cli

--- a/docs/zh/usage.md
+++ b/docs/zh/usage.md
@@ -48,7 +48,10 @@ COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
 
 #### 在 Dockerfile 中使用 PIE 的示例
 
-这是如何在 Docker 镜像中使用 PIE 安装扩展的示例。注意，与 Composer 类似，您需要安装 `unzip`、[Zip](https://www.php.net/manual/zh/book.zip.php) 扩展或 `git`。
+这是如何在 Docker 镜像中使用 PIE 安装扩展的示例。注意，与 Composer 类似，您需要安装 `unzip` 或 [Zip](https://www.php.net/manual/zh/book.zip.php) 扩展，以便解压下载的软件包。
+
+> [!NOTE]
+> 以前只安装 `git` 也可以，因为解压失败时 Composer 会回退到从源代码检出。Composer 2.10 出于安全原因移除了该回退（[composer/composer#12885](https://github.com/composer/composer/pull/12885)），而 PIE 从 1.4.8 起使用 Composer 2.10，因此仅安装 `git` 已不再足够。对于 Composer 需要通过 git 读取的仓库（例如通过 `pie repository:add vcs ...` 添加的仓库），仍然需要 `git`。
 
 ```Dockerfile
 FROM php:8.4-cli


### PR DESCRIPTION
## PR submitter checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/php/pie/blob/HEAD/CONTRIBUTING.md)
- [ ] I discussed this <bug|feature> with the maintainers in #<issue_number> (complete as appropriate)
- [ ] I have added appropriate tests
- [x] I confirm that I have the right to submit this under the project's open source licence



`docs/usage.md` states the Docker requirement as "`unzip`, the [Zip](https://www.php.net/manual/en/book.zip.php) extension, or `git`". The third option no longer works, and the failure it produces points at zip rather than at git, so it is hard to trace back to this sentence.

Composer 2.10 removed the automatic fallback from a failed dist extraction to a source checkout: *"BC Break / Security: Disabled automatic fallback to source checkout if dist/zip install fails"* (composer/composer#12885). PIE has shipped Composer 2.10 since 1.4.8 (composer/composer 2.9.8 in 1.4.7, 2.10.2 in 1.4.8, php/pie#663). In an image that only has `git`, `pie install` used to work:

```
Failed to download pecl/pcov from dist: The zip extension and unzip/7z commands are both missing, skipping.
Now trying to download from source
- Installing pecl/pcov (v1.0.12): Cloning e16c08e14d from cache
```

and now aborts:

```
Failed to download pecl/pcov from dist: The zip extension and unzip/7z commands are both missing, skipping.
Source fallback is disabled. Not trying alternative sources.
In ZipDownloader.php line 81: The zip extension and unzip/7z commands are both missing, skipping.
```

## What I verified

Each case is `pie install pecl/pcov` on `php:8.4-trixie`, differing only in what is installed:

| image contents | result |
| --- | --- |
| `unzip`, no git | installs |
| `ext-zip`, no unzip, no git | installs |
| git, no unzip, no ext-zip — PIE 1.4.7 | installs, via source checkout |
| git, no unzip, no ext-zip — PIE 1.4.8 / 1.4.9 | fails |

Bisected across `ghcr.io/php/pie:<version>-bin`: 1.4.3 through 1.4.7 install, 1.4.8 and 1.4.9 do not.

The note keeps `git` rather than dropping it, because it is still required where Composer talks to a repository over git. Same image, same commands, only `git` differing:

* without git: `No driver found to handle VCS repository /extrepo`
* with git: the Git driver is selected (it proceeds to git's own `detected dubious ownership` check)

## Branch

Opened against `1.4.x` as the oldest affected branch, per the branching strategy in the maintainers handbook — 1.3.x still ships Composer 2.9.8, where the current wording is still correct. `1.5.x` carries the same sentence and needs the same change.

## Notes

* CONTRIBUTING.md asks for an issue before code changes. This is a documentation correction with the evidence inline, so it comes as a PR directly — happy to move it to an issue first if you prefer.
* The `ja` and `zh` translations carry the same sentence and are updated to match. A native speaker should sanity-check the wording; the technical content mirrors the English note.

---

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_0129QU37uCnSL1ZkmD8bdqxQ)_
