### PR TITLE
Fix private GitHub release asset downloads

### DIFF
--- a/src/ComposerIntegration/Listeners/OverrideDownloadUrlInstallListener.php
+++ b/src/ComposerIntegration/Listeners/OverrideDownloadUrlInstallListener.php
@@ -134,7 +134,7 @@ class OverrideDownloadUrlInstallListener
                     $packageReleaseAssets = $this->container->get(PackageReleaseAssets::class);
 
                     try {
-                        $url = $packageReleaseAssets->findMatchingReleaseAssetUrl(
+                        $releaseAsset = $packageReleaseAssets->findMatchingReleaseAsset(
                             $targetPlatform,
                             $piePackage,
                             new HttpDownloader($this->io, $this->composer->getConfig()),
@@ -147,8 +147,28 @@ class OverrideDownloadUrlInstallListener
                         continue;
                     }
 
-                    $this->composerRequest->pieOutput->write('Found prebuilt archive: ' . $url);
-                    $composerPackage->setDistUrl($url);
+                    $this->composerRequest->pieOutput->write('Found prebuilt archive: ' . $releaseAsset->url);
+                    $composerPackage->setDistUrl($releaseAsset->url);
+
+                    if ($releaseAsset->headers !== []) {
+                        $transportOptions = $composerPackage->getTransportOptions();
+                        $httpOptions = $transportOptions['http'] ?? [];
+                        if (! is_array($httpOptions)) {
+                            $httpOptions = [];
+                        }
+
+                        $headers = $httpOptions['header'] ?? [];
+                        if (! is_array($headers)) {
+                            $headers = [];
+                        }
+
+                        $httpOptions['header'] = [
+                            ...$headers,
+                            ...$releaseAsset->headers,
+                        ];
+                        $transportOptions['http'] = $httpOptions;
+                        $composerPackage->setTransportOptions($transportOptions);
+                    }
 
                     // Composer's dist-sha was computed against the original
                     // Packagist URL; once we swap to a release-asset URL the
@@ -159,7 +179,7 @@ class OverrideDownloadUrlInstallListener
                         '<warning>Note: dist-sha integrity check is not available for prebuilt-binary URLs; HTTPS to the release-asset origin is the only integrity guarantee.</warning>',
                     );
 
-                    if (pathinfo($url, PATHINFO_EXTENSION) === 'tgz') {
+                    if (pathinfo($releaseAsset->name, PATHINFO_EXTENSION) === 'tgz') {
                         $composerPackage->setDistType('tar');
                     }
 

--- a/src/Downloading/GithubPackageReleaseAssets.php
+++ b/src/Downloading/GithubPackageReleaseAssets.php
@@ -25,15 +25,15 @@ final class GithubPackageReleaseAssets implements PackageReleaseAssets
     /**
      * @param non-empty-list<non-empty-string> $possibleReleaseAssetNames
      *
-     * @return non-empty-string
+     * @return ReleaseAsset
      */
-    public function findMatchingReleaseAssetUrl(
+    public function findMatchingReleaseAsset(
         TargetPlatform $targetPlatform,
         Package $package,
         HttpDownloader $httpDownloader,
         DownloadUrlMethod $downloadUrlMethod,
         array $possibleReleaseAssetNames,
-    ): string {
+    ): ReleaseAsset {
         $releaseAsset = $this->selectMatchingReleaseAsset(
             $targetPlatform,
             $package,
@@ -42,16 +42,20 @@ final class GithubPackageReleaseAssets implements PackageReleaseAssets
             $possibleReleaseAssetNames,
         );
 
-        return $releaseAsset['browser_download_url'];
+        return new ReleaseAsset(
+            $releaseAsset['url'],
+            $releaseAsset['name'],
+            ['Accept: application/octet-stream'],
+        );
     }
 
     /** @link https://github.com/squizlabs/PHP_CodeSniffer/issues/3734 */
     // phpcs:disable Squiz.Commenting.FunctionComment.MissingParamName
     /**
-     * @param list<array{name: non-empty-string, browser_download_url: non-empty-string, ...}> $releaseAssets
+     * @param list<array{name: non-empty-string, url: non-empty-string, ...}> $releaseAssets
      * @param non-empty-list<non-empty-string> $possibleReleaseAssetNames
      *
-     * @return array{name: non-empty-string, browser_download_url: non-empty-string, ...}
+     * @return array{name: non-empty-string, url: non-empty-string, ...}
      */
     // phpcs:enable
     private function selectMatchingReleaseAsset(
@@ -70,7 +74,7 @@ final class GithubPackageReleaseAssets implements PackageReleaseAssets
         throw Exception\CouldNotFindReleaseAsset::forPackage($targetPlatform, $package, $downloadUrlMethod, $possibleReleaseAssetNames);
     }
 
-    /** @return list<array{name: non-empty-string, browser_download_url: non-empty-string, ...}> */
+    /** @return list<array{name: non-empty-string, url: non-empty-string, ...}> */
     private function getReleaseAssetsForPackage(
         Package $package,
         HttpDownloader $httpDownloader,
@@ -106,8 +110,8 @@ final class GithubPackageReleaseAssets implements PackageReleaseAssets
             static function (array $asset): array {
                 Assert::keyExists($asset, 'name');
                 Assert::stringNotEmpty($asset['name']);
-                Assert::keyExists($asset, 'browser_download_url');
-                Assert::stringNotEmpty($asset['browser_download_url']);
+                Assert::keyExists($asset, 'url');
+                Assert::stringNotEmpty($asset['url']);
 
                 return $asset;
             },

--- a/src/Downloading/PackageReleaseAssets.php
+++ b/src/Downloading/PackageReleaseAssets.php
@@ -14,13 +14,13 @@ interface PackageReleaseAssets
     /**
      * @param non-empty-list<non-empty-string> $possibleReleaseAssetNames
      *
-     * @return non-empty-string
+     * @return ReleaseAsset
      */
-    public function findMatchingReleaseAssetUrl(
+    public function findMatchingReleaseAsset(
         TargetPlatform $targetPlatform,
         Package $package,
         HttpDownloader $httpDownloader,
         DownloadUrlMethod $downloadUrlMethod,
         array $possibleReleaseAssetNames,
-    ): string;
+    ): ReleaseAsset;
 }

--- a/src/Downloading/ReleaseAsset.php
+++ b/src/Downloading/ReleaseAsset.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Php\Pie\Downloading;
+
+/** @internal This is not public API for PIE, so should not be depended upon unless you accept the risk of BC breaks */
+final class ReleaseAsset
+{
+    /**
+     * @param non-empty-string      $url
+     * @param non-empty-string      $name
+     * @param list<non-empty-string> $headers
+     */
+    public function __construct(
+        public readonly string $url,
+        public readonly string $name,
+        public readonly array $headers = [],
+    ) {
+    }
+}

--- a/test/integration/Downloading/GithubPackageReleaseAssetsTest.php
+++ b/test/integration/Downloading/GithubPackageReleaseAssetsTest.php
@@ -11,6 +11,7 @@ use Composer\Util\HttpDownloader;
 use Php\Pie\DependencyResolver\Package;
 use Php\Pie\Downloading\DownloadUrlMethod;
 use Php\Pie\Downloading\GithubPackageReleaseAssets;
+use Php\Pie\Downloading\ReleaseAsset;
 use Php\Pie\ExtensionName;
 use Php\Pie\ExtensionType;
 use Php\Pie\Platform\Architecture;
@@ -60,10 +61,14 @@ final class GithubPackageReleaseAssetsTest extends TestCase
         $config = Factory::createConfig();
         $io->loadConfiguration($config);
 
-        self::assertSame(
-            'https://github.com/asgrim/example-pie-extension/releases/download/2.0.2/php_example_pie_extension-2.0.2-8.3-ts-vs16-x86_64.zip',
+        self::assertEquals(
+            new ReleaseAsset(
+                'https://api.github.com/repos/asgrim/example-pie-extension/releases/assets/197867674',
+                'php_example_pie_extension-2.0.2-8.3-ts-vs16-x86_64.zip',
+                ['Accept: application/octet-stream'],
+            ),
             (new GithubPackageReleaseAssets('https://api.github.com'))
-                ->findMatchingReleaseAssetUrl(
+                ->findMatchingReleaseAsset(
                     $targetPlatform,
                     $package,
                     new HttpDownloader($io, $config),

--- a/test/unit/ComposerIntegration/Listeners/OverrideDownloadUrlInstallListenerTest.php
+++ b/test/unit/ComposerIntegration/Listeners/OverrideDownloadUrlInstallListenerTest.php
@@ -22,6 +22,7 @@ use Php\Pie\DependencyResolver\RequestedPackageAndVersion;
 use Php\Pie\Downloading\DownloadUrlMethod;
 use Php\Pie\Downloading\Exception\CouldNotFindReleaseAsset;
 use Php\Pie\Downloading\PackageReleaseAssets;
+use Php\Pie\Downloading\ReleaseAsset;
 use Php\Pie\Platform\Architecture;
 use Php\Pie\Platform\OperatingSystem;
 use Php\Pie\Platform\OperatingSystemFamily;
@@ -283,8 +284,8 @@ final class OverrideDownloadUrlInstallListenerTest extends TestCase
         $packageReleaseAssets = $this->createMock(PackageReleaseAssets::class);
         $packageReleaseAssets
             ->expects(self::once())
-            ->method('findMatchingReleaseAssetUrl')
-            ->willReturn('https://example.com/windows-download-url');
+            ->method('findMatchingReleaseAsset')
+            ->willReturn(new ReleaseAsset('https://example.com/windows-download-url', 'windows-download-url.zip', ['Accept: application/octet-stream']));
 
         $this->container
             ->method('get')
@@ -319,6 +320,15 @@ final class OverrideDownloadUrlInstallListenerTest extends TestCase
             $composerPackage->getDistUrl(),
         );
         self::assertSame(DownloadUrlMethod::WindowsBinaryDownload, DownloadUrlMethod::fromComposerPackage($composerPackage));
+        $transportOptions = $composerPackage->getTransportOptions();
+        self::assertArrayHasKey('http', $transportOptions);
+        self::assertIsArray($transportOptions['http']);
+        $httpOptions = $transportOptions['http'];
+        self::assertArrayHasKey('header', $httpOptions);
+        self::assertSame(
+            ['Accept: application/octet-stream'],
+            $httpOptions['header'],
+        );
     }
 
     public function testDistUrlIsUpdatedForPrePackagedTgzSource(): void
@@ -343,8 +353,8 @@ final class OverrideDownloadUrlInstallListenerTest extends TestCase
         $packageReleaseAssets = $this->createMock(PackageReleaseAssets::class);
         $packageReleaseAssets
             ->expects(self::once())
-            ->method('findMatchingReleaseAssetUrl')
-            ->willReturn('https://example.com/pre-packaged-source-download-url.tgz');
+            ->method('findMatchingReleaseAsset')
+            ->willReturn(new ReleaseAsset('https://example.com/pre-packaged-source-download-url.tgz', 'pre-packaged-source-download-url.tgz'));
 
         $this->container
             ->method('get')
@@ -404,8 +414,8 @@ final class OverrideDownloadUrlInstallListenerTest extends TestCase
         $packageReleaseAssets = $this->createMock(PackageReleaseAssets::class);
         $packageReleaseAssets
             ->expects(self::once())
-            ->method('findMatchingReleaseAssetUrl')
-            ->willReturn('https://example.com/pre-packaged-binary-download-url.tgz');
+            ->method('findMatchingReleaseAsset')
+            ->willReturn(new ReleaseAsset('https://example.com/pre-packaged-binary-download-url.tgz', 'pre-packaged-binary-download-url.tgz'));
 
         $this->container
             ->method('get')
@@ -465,7 +475,7 @@ final class OverrideDownloadUrlInstallListenerTest extends TestCase
         $packageReleaseAssets = $this->createMock(PackageReleaseAssets::class);
         $packageReleaseAssets
             ->expects(self::once())
-            ->method('findMatchingReleaseAssetUrl')
+            ->method('findMatchingReleaseAsset')
             ->willThrowException(new CouldNotFindReleaseAsset('nope not found'));
 
         $this->container
@@ -583,8 +593,8 @@ final class OverrideDownloadUrlInstallListenerTest extends TestCase
         $packageReleaseAssets = $this->createMock(PackageReleaseAssets::class);
         $packageReleaseAssets
             ->expects(self::once())
-            ->method('findMatchingReleaseAssetUrl')
-            ->willReturn('https://example.com/windows-download-url');
+            ->method('findMatchingReleaseAsset')
+            ->willReturn(new ReleaseAsset('https://example.com/windows-download-url', 'windows-download-url.zip'));
 
         $this->container
             ->method('get')
@@ -643,7 +653,7 @@ final class OverrideDownloadUrlInstallListenerTest extends TestCase
         $packageReleaseAssets = $this->createMock(PackageReleaseAssets::class);
         $packageReleaseAssets
             ->expects(self::once())
-            ->method('findMatchingReleaseAssetUrl')
+            ->method('findMatchingReleaseAsset')
             ->willThrowException(new CouldNotFindReleaseAsset('nope not found'));
 
         $this->container

--- a/test/unit/Downloading/GithubPackageReleaseAssetsTest.php
+++ b/test/unit/Downloading/GithubPackageReleaseAssetsTest.php
@@ -12,6 +12,7 @@ use Php\Pie\DependencyResolver\Package;
 use Php\Pie\Downloading\DownloadUrlMethod;
 use Php\Pie\Downloading\Exception\CouldNotFindReleaseAsset;
 use Php\Pie\Downloading\GithubPackageReleaseAssets;
+use Php\Pie\Downloading\ReleaseAsset;
 use Php\Pie\ExtensionName;
 use Php\Pie\ExtensionType;
 use Php\Pie\Platform\Architecture;
@@ -28,6 +29,7 @@ use PHPUnit\Framework\TestCase;
 use function uniqid;
 
 #[CoversClass(GithubPackageReleaseAssets::class)]
+#[CoversClass(ReleaseAsset::class)]
 final class GithubPackageReleaseAssetsTest extends TestCase
 {
     public function testUrlIsReturnedWhenFindingWindowsDownloadUrl(): void
@@ -56,11 +58,11 @@ final class GithubPackageReleaseAssetsTest extends TestCase
                 'assets' => [
                     [
                         'name' => 'php_foo-1.2.3-8.3-vc14-nts-x86.zip',
-                        'browser_download_url' => 'wrong_download_url',
+                        'url' => 'wrong_download_url',
                     ],
                     [
                         'name' => 'php_foo-1.2.3-8.3-vc14-ts-x86.zip',
-                        'browser_download_url' => 'actual_download_url',
+                        'url' => 'actual_download_url',
                     ],
                 ],
             ]);
@@ -82,9 +84,9 @@ final class GithubPackageReleaseAssetsTest extends TestCase
 
         $releaseAssets = new GithubPackageReleaseAssets('https://test-github-api-base-url.thephp.foundation');
 
-        self::assertSame(
-            'actual_download_url',
-            $releaseAssets->findMatchingReleaseAssetUrl(
+        self::assertEquals(
+            new ReleaseAsset('actual_download_url', 'php_foo-1.2.3-8.3-vc14-ts-x86.zip', ['Accept: application/octet-stream']),
+            $releaseAssets->findMatchingReleaseAsset(
                 $targetPlatform,
                 $package,
                 $httpDownloader,
@@ -123,11 +125,11 @@ final class GithubPackageReleaseAssetsTest extends TestCase
                 'assets' => [
                     [
                         'name' => 'php_foo-1.2.3-8.3-nts-vc14-x86.zip',
-                        'browser_download_url' => 'wrong_download_url',
+                        'url' => 'wrong_download_url',
                     ],
                     [
                         'name' => 'php_foo-1.2.3-8.3-ts-vc14-x86.zip',
-                        'browser_download_url' => 'actual_download_url',
+                        'url' => 'actual_download_url',
                     ],
                 ],
             ]);
@@ -149,9 +151,9 @@ final class GithubPackageReleaseAssetsTest extends TestCase
 
         $releaseAssets = new GithubPackageReleaseAssets('https://test-github-api-base-url.thephp.foundation');
 
-        self::assertSame(
-            'actual_download_url',
-            $releaseAssets->findMatchingReleaseAssetUrl(
+        self::assertEquals(
+            new ReleaseAsset('actual_download_url', 'php_foo-1.2.3-8.3-ts-vc14-x86.zip', ['Accept: application/octet-stream']),
+            $releaseAssets->findMatchingReleaseAsset(
                 $targetPlatform,
                 $package,
                 $httpDownloader,
@@ -198,7 +200,7 @@ final class GithubPackageReleaseAssetsTest extends TestCase
         $releaseAssets = new GithubPackageReleaseAssets('https://test-github-api-base-url.thephp.foundation');
 
         $this->expectException(CouldNotFindReleaseAsset::class);
-        $releaseAssets->findMatchingReleaseAssetUrl(
+        $releaseAssets->findMatchingReleaseAsset(
             $targetPlatform,
             $package,
             $httpDownloader,


### PR DESCRIPTION
## Summary
- download GitHub release assets through the authenticated API endpoint
- request binary asset content with the required Accept header
- preserve asset filename for archive-type detection

Fixes #715.

## Verification
- vendor/bin/phpunit test/unit/Downloading/GithubPackageReleaseAssetsTest.php test/unit/ComposerIntegration/Listeners/OverrideDownloadUrlInstallListenerTest.php
- vendor/bin/phpstan analyse --debug src/Downloading/ReleaseAsset.php src/Downloading/PackageReleaseAssets.php src/Downloading/GithubPackageReleaseAssets.php src/ComposerIntegration/Listeners/OverrideDownloadUrlInstallListener.php test/unit/Downloading/GithubPackageReleaseAssetsTest.php test/unit/ComposerIntegration/Listeners/OverrideDownloadUrlInstallListenerTest.php
- verified against the reported private release asset with curl and Composer's HttpDownloader