### PR TITLE
Remove gh CLI from brew image as it isn't used

### DIFF
--- a/test/end-to-end/Dockerfile
+++ b/test/end-to-end/Dockerfile
@@ -38,7 +38,7 @@ FROM homebrew_base AS test_pie_installs_build_tools_with_brew
 RUN brew update && brew install php
 COPY --from=build_pie_phar /app/pie.phar /usr/local/bin/pie
 USER root
-RUN apt-get update && apt-get install -y unzip
+RUN rm -f /etc/apt/sources.list.d/github-cli.list && apt-get update && apt-get install -y unzip
 RUN apt-get remove --allow-remove-essential -y apt
 USER linuxbrew
 RUN pie install --auto-install-build-tools -v asgrim/example-pie-extension:2.0.5


### PR DESCRIPTION
Sidestep the key issue by removing `gh` from the brew image, it's not needed

## PR submitter checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/php/pie/blob/HEAD/CONTRIBUTING.md)
- [x] I discussed this bug with the maintainers in my head
- [x] I have added appropriate tests
- [x] I confirm that I have the right to submit this under the project's open source licence
