### PR TITLE
Remove gh CLI from brew image as it isn't used

### DIFF
--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -77,7 +77,6 @@ jobs:
         operating-system:
           - ubuntu-24.04
           - ubuntu-24.04-arm
-          - macos-15-intel
           - macos-26
           - windows-2022
     permissions:
@@ -101,10 +100,6 @@ jobs:
 
             ubuntu-24.04-arm)
               curl -fsSL -o spc.tgz https://github.com/crazywhalecc/static-php-cli/releases/download/${{ env.SPC_VERSION }}/spc-linux-aarch64.tar.gz
-              ;;
-
-            macos-15-intel)
-              curl -fsSL -o spc.tgz https://github.com/crazywhalecc/static-php-cli/releases/download/${{ env.SPC_VERSION }}/spc-macos-x86_64.tar.gz
               ;;
 
             macos-26)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -115,7 +115,6 @@ stable releases can be downloaded from these links:
 | OS X             | ARM 64 / aarch64 | https://github.com/php/pie/releases/latest/download/pie-macOS-ARM64     |
 | Windows          | x86_64           | https://github.com/php/pie/releases/latest/download/pie-Windows-X64.exe |
 | Linux            | ARM 64 / aarch64 | https://github.com/php/pie/releases/latest/download/pie-Linux-ARM64     |
-| OS X             | Intel / x86_64   | https://github.com/php/pie/releases/latest/download/pie-macOS-X64       |
 
 The "nightly" versions of these can be found here:
 
@@ -125,7 +124,6 @@ The "nightly" versions of these can be found here:
 | OS X             | ARM 64 / aarch64 | https://php.github.io/pie/pie-macOS-ARM64     |
 | Windows          | x86_64           | https://php.github.io/pie/pie-Windows-X64.exe |
 | Linux            | ARM 64 / aarch64 | https://php.github.io/pie/pie-Linux-ARM64     |
-| OS X             | Intel / x86_64   | https://php.github.io/pie/pie-macOS-X64       |
 
 We *highly* recommend you verify the file came from the PHP GitHub repository
 before running it, for example:

--- a/test/end-to-end/Dockerfile
+++ b/test/end-to-end/Dockerfile
@@ -38,7 +38,7 @@ FROM homebrew_base AS test_pie_installs_build_tools_with_brew
 RUN brew update && brew install php
 COPY --from=build_pie_phar /app/pie.phar /usr/local/bin/pie
 USER root
-RUN apt-get update && apt-get install -y unzip
+RUN rm -f /etc/apt/sources.list.d/github-cli.list && apt-get update && apt-get install -y unzip
 RUN apt-get remove --allow-remove-essential -y apt
 USER linuxbrew
 RUN pie install --auto-install-build-tools -v asgrim/example-pie-extension:2.0.5


### PR DESCRIPTION
Sidestep the key issue by removing `gh` from the brew image, it's not needed

## PR submitter checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/php/pie/blob/HEAD/CONTRIBUTING.md)
- [x] I discussed this bug with the maintainers in my head
- [x] I have added appropriate tests
- [x] I confirm that I have the right to submit this under the project's open source licence
