### PR TITLE
Remove OSX Intel executable builds from PIE (and merge up 1.4.x)

### DIFF
--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -77,7 +77,6 @@ jobs:
         operating-system:
           - ubuntu-24.04
           - ubuntu-24.04-arm
-          - macos-15-intel
           - macos-26
           - windows-2022
     permissions:
@@ -101,10 +100,6 @@ jobs:
 
             ubuntu-24.04-arm)
               curl -fsSL -o spc.tgz https://github.com/crazywhalecc/static-php-cli/releases/download/${{ env.SPC_VERSION }}/spc-linux-aarch64.tar.gz
-              ;;
-
-            macos-15-intel)
-              curl -fsSL -o spc.tgz https://github.com/crazywhalecc/static-php-cli/releases/download/${{ env.SPC_VERSION }}/spc-macos-x86_64.tar.gz
               ;;
 
             macos-26)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -115,7 +115,6 @@ stable releases can be downloaded from these links:
 | OS X             | ARM 64 / aarch64 | https://github.com/php/pie/releases/latest/download/pie-macOS-ARM64     |
 | Windows          | x86_64           | https://github.com/php/pie/releases/latest/download/pie-Windows-X64.exe |
 | Linux            | ARM 64 / aarch64 | https://github.com/php/pie/releases/latest/download/pie-Linux-ARM64     |
-| OS X             | Intel / x86_64   | https://github.com/php/pie/releases/latest/download/pie-macOS-X64       |
 
 The "nightly" versions of these can be found here:
 
@@ -125,7 +124,6 @@ The "nightly" versions of these can be found here:
 | OS X             | ARM 64 / aarch64 | https://php.github.io/pie/pie-macOS-ARM64     |
 | Windows          | x86_64           | https://php.github.io/pie/pie-Windows-X64.exe |
 | Linux            | ARM 64 / aarch64 | https://php.github.io/pie/pie-Linux-ARM64     |
-| OS X             | Intel / x86_64   | https://php.github.io/pie/pie-macOS-X64       |
 
 We *highly* recommend you verify the file came from the PHP GitHub repository
 before running it, for example:


### PR DESCRIPTION
merge up 1.4.x - brings in #728 into 1.5.x (properly this time....)

OSX Intel executable builds are now unfortunately removed going forward; we can't practically build them any more without further upstream work (which probably futile/high effort/low value/low impact): shivammathur/setup-php'1112